### PR TITLE
fix for pointdensity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
     - id: black
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
     - id: flake8

--- a/brainrender/actors/points.py
+++ b/brainrender/actors/points.py
@@ -76,7 +76,9 @@ class PointsBase:
 
 
 class Points(PointsBase, Actor):
-    def __init__(self, data, name=None, colors="salmon", alpha=1, radius=20, res=8):
+    def __init__(
+        self, data, name=None, colors="salmon", alpha=1, radius=20, res=8
+    ):
         """
         Creates an actor representing multiple points (more efficient than
         creating many Point instances).
@@ -89,7 +91,7 @@ class Points(PointsBase, Actor):
         :param res: int. Resolution of sphere actors
         """
         PointsBase.__init__(self)
-        logger.debug(f"Creating a Points actor")
+        logger.debug("Creating a Points actor")
 
         self.radius = radius
         self.colors = colors
@@ -129,8 +131,17 @@ class PointsDensity(Actor):
             :param int,list dims: numer of voxels in x, y and z of the output Volume.
 
         """
-        logger.debug(f"Creating a PointsDensity actor")
-        volume = vPoints(data).density(
-            dims=dims, radius=radius, **kwargs
+        logger.debug("Creating a PointsDensity actor")
+
+        # flip coordinates on XY axis to match brainrender coordinates system
+        data[:, 2] = -data[:, 2]
+
+        # create volume and then actor
+        volume = (
+            vPoints(data)
+            .density(dims=dims, radius=radius, **kwargs)
+            .c("Dark2")
+            .alpha([0, 0.9])
+            .mode(1)
         )  # returns a vedo Volume
         Actor.__init__(self, volume, name=name, br_class="density")

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -15,6 +15,7 @@ from brainrender.camera import (
     set_camera,
     get_camera_params,
 )
+from brainrender.actors.points import PointsDensity
 
 
 # mtx used to transform meshes to sort axes orientation
@@ -116,6 +117,12 @@ class Render:
 
         Once an actor is 'corrected' it spawns labels and silhouettes as needed
         """
+        # don't apply transforms to points density actors
+        if isinstance(actor, PointsDensity):
+            logger.debug(
+                f'Not transforming actor "{actor.name} (type: {actor.br_class})"'
+            )
+            actor._is_transformed = True
 
         # Flip every actor's orientation
         if not actor._is_transformed:
@@ -123,11 +130,17 @@ class Render:
                 actor._mesh = actor.mesh.clone()
                 actor._mesh.applyTransform(mtx)
             except AttributeError:  # some types of actors dont trasform
+                logger.debug(
+                    f'Failed to transform actor: "{actor.name} (type: {actor.br_class})"'
+                )
                 actor._is_transformed = True
             else:
                 try:
                     actor.mesh.reverse()
                 except AttributeError:  # Volumes don't have reverse
+                    logger.debug(
+                        f'Failed to reverse actor: "{actor.name} (type: {actor.br_class})"'
+                    )
                     pass
                 actor._is_transformed = True
 


### PR DESCRIPTION
Fix for https://github.com/brainglobe/brainrender/issues/107#issuecomment-979991376 following discussion at https://github.com/marcomusy/vedo/issues/547

@adamltyson , @vigji , brainrender has a `actors.points.PointDensity` class that creates 3D density plots from a set of coordinates:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/17436313/144138705-496ad2ad-a666-48a6-b183-a904254e304a.png">


This was broken and now I've fixed it, but it's kind of an ugly fix. 
Brainrender normally mirrors meshes on the AP plane to keep the axes orientations consistent with other brainglobe software (a real pain btw). To make the rendering work, the meshes normals need to be recomputed after the transformation. For `PointDensity` I can't do this since the `vedo.Volume` actor it produces cannot recompute normals, so I can't apply the transform or it will look horrible.
The only solution I've found is to mirror the coordinates of the points before these are used to create the `PointsDensity` actor, but that's not very elegant. I'm also not sure if this would work correctly for atlases with different orientations.

What do you guys think? Any idea for a better fix?