### PR TITLE
invert parameter missing

### DIFF
--- a/brainrender/scene.py
+++ b/brainrender/scene.py
@@ -353,6 +353,7 @@ class Scene(JupyterMixIn, Render):
         plane,
         actors=None,
         close_actors=False,
+        invert=False
     ):
         """
         Slices actors with a plane.


### PR DESCRIPTION
Hi Federico,
Thanks for accepting the pull request last time, I just tried it out and realized that the invert parameter is missing here: https://github.com/brainglobe/brainrender/blob/6d65ad4159462e3c97a2e26c95109f3f131dc397/brainrender/scene.py#L351-L356

Saluti!