### PR TITLE
Add link to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can [install `brainrender`](https://docs.brainrender.info/installation/insta
 pip install brainrender
 ``` 
 
+## Contributing
+Contributions to brainrender are more than welcome. Please see the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).
+
 ## Citing brainrender
 If you use `brainrender` in your work, please cite:
 ```


### PR DESCRIPTION
Hey @FedeClaudi, I'm going round and adding an explicit link to the contributing guidelines in all the readme's (otherwise it only comes up when someone opens a new issue/PR).

Feel free to ignore if you don't want it added.