### PR TITLE
Changed 'lexer_name' param to 'lexer' for rich update

### DIFF
--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -43,7 +43,7 @@ class not_on_jupyter:  # pragma: no cover
             print(
                 f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook",
                 f"[{orange_dark}]Try setting the correct backend before creating your scene:\n",
-                Syntax("from vedo import embedWindow", lexer_name="python"),
-                Syntax("embedWindow(None)", lexer_name="python"),
+                Syntax("from vedo import embedWindow", lexer="python"),
+                Syntax("embedWindow(None)", lexer="python"),
             )
             return None

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -262,17 +262,17 @@ class Render:
             self.remove(*self.get_actors(br_class="silhouette"))
             print(
                 f"[{teal}]Your scene is ready for rendering, use:\n",
-                Syntax("from vedo import show", lexer_name="python"),
-                Syntax("vedo.show(*scene.renderables)", lexer_name="python"),
+                Syntax("from vedo import show", lexer="python"),
+                Syntax("vedo.show(*scene.renderables)", lexer="python"),
                 sep="\n",
             )
         else:  # pragma: no cover
             print(
                 f"[{teal}]Your scene is ready for rendering, use:\n",
-                Syntax("from itkwidgets import view", lexer_name="python"),
+                Syntax("from itkwidgets import view", lexer="python"),
                 Syntax(
                     "view(scene.plotter.show(*scene.renderables))",
-                    lexer_name="python",
+                    lexer="python",
                 ),
                 sep="\n",
             )


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ X ] Bug fix
- [x] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Because a new version of rich is not compatible with previous versions of brainrender.

**What does this PR do?**
Changes the name of the parameter 'lexer_name' to 'lexer' to accommodate the change in newer versions of the rich dependency.

## References
Issue #219

## How has this PR been tested?
N/A

## Is this a breaking change?
Shouldn't be. But rich's version should be updated.

## Does this PR require an update to the documentation?
The version of Rich specified with pip or other dependency documentation should be updated.

## Checklist:

- [ x ] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [ x ] The code has been formatted with [pre-commit](https://pre-commit.com/)
