### PR TITLE
minor installation/test running fixing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10",]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:
         - os: macos-latest
-          python-version: "3.10"
+          python-version: "3.11"
         - os: windows-latest
-          python-version: "3.10"
+          python-version: "3.11"
 
     steps:
       # Run tests

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,6 +19,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Run all supported Python versions on linux
         python-version: ["3.9", "3.10", "3.11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ dev = [
   "mypy",
   "pre-commit",
   "ruff",
-  "setuptools_scm"
+  "setuptools_scm",
+  "pyside2"
 ]
 nb = ["jupyter", "k3d"]
         pyside2= ["PySide2"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{38,39,310}
+envlist = py{39,310,311}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 extras =


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

- I managed to remove a `pyside2` dev dependency in the `mega-fix` branch, which was needed
- we should stop supporting py3.8 and test on py3.11 to follow NEP 29
- CI currently fails fast, so it's hard to get an overview of how tests are faring across OSs and Python version

**What does this PR do?**

- adds `pyside2` to dependencies
- drops support for Python 3.8.
- ensures all CI workflows are run even if one fails by setting `strategy.fail-fast = false`

## References

Closes #252 
Closes #256 

## How has this PR been tested?

Tests fail due to other reasons that lack of Qt back [in CI run](https://github.com/brainglobe/brainrender/actions/runs/6652661314)

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Not really, but see https://github.com/brainglobe/brainrender/issues/253 for docs changes/improvements needed as part of megafix

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
