### PR TITLE
Potential fix for test_ruler_from_surface, removed transformation

### DIFF
--- a/brainrender/actors/ruler.py
+++ b/brainrender/actors/ruler.py
@@ -66,7 +66,7 @@ def ruler_from_surface(
     p2 = p1.copy()
     p2[axis] = 0  # zero the chosen coordinate
 
-    pts = root.mesh.intersectWithLine(p1, p2)
+    pts = root.mesh.intersect_with_line(p1, p2)
     surface_point = pts[0]
 
     return ruler(p1, surface_point, unit_scale=unit_scale, units=units, s=s)

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -129,7 +129,7 @@ class Render:
         if not actor._is_transformed:
             try:
                 actor._mesh = actor.mesh.clone()
-                actor._mesh.apply_transform(mtx)
+                # actor._mesh.apply_transform(mtx)
             except AttributeError:  # some types of actors don't transform
                 logger.debug(
                     f'Failed to transform actor: "{actor.name} (type: {actor.br_class})"'


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Fix the test_ruler.py::test_ruler_from_surface.

**What does this PR do?**
Update the API calls to vedo for intersectWithLine(). Removing the Mesh::apply_transform call to meshes in render,py fixes the test and also allows most examples to render correctly (without weird transpositions - cells outside of the brain region, etc...). 

## References
Closes #255 

## How has this PR been tested?
Tested locally, all non-slow tests pass!

## Is this a breaking change?
No

## Checklist:

- [x] The code has been tested locally
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
