### PR TITLE
Fix windows install

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -32,6 +32,19 @@ jobs:
           python-version: "3.11"
 
     steps:
+      - name: Setup conda on Windows
+        if: runner.os == 'Windows'
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: ${{ matrix.python-version }}
+          conda-channels: conda-forge
+
+      - name: Install Windows-specific conda-forge dependencies
+        if: runner.os == 'Windows'
+        run: conda install -c conda-forge pyside2
+
+
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -29,22 +29,9 @@ jobs:
         - os: macos-latest
           python-version: "3.11"
         - os: windows-latest
-          python-version: "3.11"
+          python-version: "3.10"
 
     steps:
-      - name: Setup conda on Windows
-        if: runner.os == 'Windows'
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: conda-forge
-
-      - name: Install Windows-specific conda-forge dependencies
-        if: runner.os == 'Windows'
-        run: conda install -c conda-forge pyside2
-
-
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "pandas",
+    "h5py<=3.9", # vedo requires hdf5 <=1.12.x but hdf5 is 1.14+ from h5py 3.10 onwards
     "vedo",
     "k3d",
     "imio",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

CI installation fails on Windows.

**What does this PR do?**

Hard-codes h5py<=3.9 dependency.

## References

temporary fix #258 - don't support python 3.11 for Windows GUI for now. 

## How has this PR been tested?

CI install is successful (although tests fail)

## Is this a breaking change?

Nope.

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
