### PR TITLE
use pyvista action for headless display in tox

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,6 +36,9 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install hdf5
 
+      # Helps set up VTK with a headless display
+      - uses: pyvista/setup-headless-display-action@v2
+
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,9 @@ extras =
 commands =
     pytest -v --color=yes --cov=brainrender --cov-report=xml
 passenv =
+    CI
+    GITHUB_ACTIONS
     DISPLAY
+    XAUTHORITY
+    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
+    PYVISTA_OFF_SCREEN


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tests fail weirdly with a display-related thing on Windows CI.

**What does this PR do?**

Brings the CI set-up of the headless display in line with `napari` and our `napari` plugins, ie uses a `pyvista` GitHub action to set up the headless display.

## References

Closes #270 

## How has this PR been tested?

CI tests now all pass :tada: 

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [NA] The code has been tested locally
- [NA] Tests have been added to cover all new functionality (unit & integration)
- [NA] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)