### PR TITLE
Fix `test_export_html` and run it on CI

### DIFF
--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -289,6 +289,7 @@ class Render:
         """
         logger.debug(f"Exporting scene to {savepath}")
         _backend = self.backend
+        _default_backend = vsettings.default_backend
 
         if not self.is_rendered:
             self.render(interactive=False)
@@ -314,7 +315,7 @@ class Render:
         )
 
         # Reset settings
-        vsettings.notebookBackend = None
+        vsettings.default_backend = _default_backend
         self.backend = _backend
 
         return str(path)

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -302,7 +302,7 @@ class Render:
 
         # Create new plotter and save to file
         plt = Plotter()
-        plt.add(self.clean_renderables, render=False)
+        plt.add(self.clean_renderables).render()
         plt = plt.show(interactive=False)
         plt.camera[-2] = -1
 

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -305,7 +305,6 @@ class Render:
         plt = Plotter()
         plt.add(self.clean_renderables).render()
         plt = plt.show(interactive=False)
-        plt.camera[-2] = -1
 
         with open(path, "w") as fp:
             fp.write(plt.get_snapshot())

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -5,15 +5,19 @@ import pytest
 from brainrender import Scene
 
 
-@pytest.mark.local
-def test_export_for_web():
+@pytest.fixture
+def scene():
+    """Provide a scene with a brain region"""
     s = Scene(title="BR")
-
     th = s.add_brain_region("TH")
-
     s.add_label(th, "TH")
+    return s
 
-    path = s.export("test.html")
+
+@pytest.mark.local
+def test_export_for_web(scene):
+    """Check that exporting to html creates the expected file"""
+    path = scene.export("test.html")
     assert path == "test.html"
 
     path = Path(path)
@@ -21,5 +25,9 @@ def test_export_for_web():
 
     path.unlink()
 
+
+@pytest.mark.local
+def test_export_for_web_raises(scene):
+    """Check that exporting with invalid file extention raises ValueError"""
     with pytest.raises(ValueError):
-        path = s.export("test.py")
+        scene.export("test.py")

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -14,7 +14,6 @@ def scene():
     return s
 
 
-@pytest.mark.local
 def test_export_for_web(scene):
     """Check that exporting to html creates the expected file"""
     path = scene.export("test.html")
@@ -26,7 +25,6 @@ def test_export_for_web(scene):
     path.unlink()
 
 
-@pytest.mark.local
 def test_export_for_web_raises(scene):
     """Check that exporting with invalid file extention raises ValueError"""
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The previously `pytest.mark.local` test `test_export_html.py` was failing locally.

**What does this PR do?**
* Makes `test_export_html.py` pass locally and now also on the CI system, achieved by:
   * I had a visual look at the created `test.html` file and it looks as I would expect it (below).
   * updated calls to vedo
   * the decision that the `export` function should not affect the current camera, and therefore removing a line from `export()`.
* Minor refactor of the test so it's more modular

![image](https://github.com/brainglobe/brainrender/assets/10500965/4742b44b-ccfc-4005-b915-ac1e6b82dc4d)

## References

Closes #274 

## How has this PR been tested?

CI passes with new non-local test. Note there was a presumably spurious crash [on the Windows CI at one commit here](https://github.com/brainglobe/brainrender/actions/runs/6878493665/job/18708343153).

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [NA] Tests have been added to cover all new functionality (unit & integration)
- [NA] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
