### PR TITLE
Fix video test

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -39,6 +39,10 @@ jobs:
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2
 
+      # Sets up ffmpeg to we can run video tests on CI
+      - uses: FedericoCarboni/setup-ffmpeg@v2
+        id: setup-ffmpeg
+
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,12 +1,9 @@
 from pathlib import Path
 
-import pytest
-
 from brainrender.scene import Scene
 from brainrender.video import Animation, VideoMaker
 
 
-@pytest.mark.local
 def test_video():
     s = Scene(title="BR")
 
@@ -21,7 +18,6 @@ def test_video():
     path.unlink()
 
 
-@pytest.mark.local
 def test_video_custom():
     def custom(scene, *args, **kwargs):
         return
@@ -40,7 +36,6 @@ def test_video_custom():
     path.unlink()
 
 
-@pytest.mark.local
 def test_animation():
     # Create a brainrender scene
     scene = Scene(title="brain regions", inset=False)


### PR DESCRIPTION
⚠️ Depends on #277 being merged first 

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The local video tests fail because we don't install, or document anywhere explicit, (AFAICT) that `ffmpeg` is needed (the command line tool).

**What does this PR do?**
Makes the video tests not local, and sets up `ffmpeg` on CI.

## References

People have struggled with this before: #202 


## How has this PR been tested?

This PR adds extra tests (previously only run locally) to the CI

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
