### PR TITLE
Remove setting of user-dependent FXAA vedo setting

### DIFF
--- a/brainrender/settings.py
+++ b/brainrender/settings.py
@@ -21,7 +21,6 @@ vsettings.multi_samples = 0 if sys.platform == "darwin" else 8
 
 # For transparent background with screenshots
 vsettings.screenshot_transparent_background = False  # vedo for transparent bg
-vsettings.use_fxaa = True  # This needs to be false for transparent bg
 
 
 # --------------------------- brainrender settings --------------------------- #

--- a/brainrender/settings.py
+++ b/brainrender/settings.py
@@ -21,6 +21,7 @@ vsettings.multi_samples = 0 if sys.platform == "darwin" else 8
 
 # For transparent background with screenshots
 vsettings.screenshot_transparent_background = False  # vedo for transparent bg
+vsettings.use_fxaa = False
 
 
 # --------------------------- brainrender settings --------------------------- #


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Brainrender examples don't render correctly on some machines - see #240 and related forum discussion

**What does this PR do?**
Removes the explicit setting of a `vedo` setting that messes with rendering.

## References

Closes #240 

## How has this PR been tested?

Local running of 
```
import brainrender
scene=brainrender.Scene(atlas_name="allen_mouse_25um")
scene.render()
```

## Is this a breaking change?

Yes, if anyone was relying on `use_FXAA` being set to true.

## Does this PR require an update to the documentation?
Don't think this was documented anywhere in the first place, so not specifically?

## Checklist:

- [x] The code has been tested locally (manually)
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
