### PR TITLE
Switch PySide2 for PyQt5

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,10 +36,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install hdf5
 
-      - name: Install pyside2 for Windows
-        if: runner.os == 'Windows'
-        run: conda install -c conda-forge pyside2
-
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -29,12 +29,16 @@ jobs:
         - os: macos-latest
           python-version: "3.11"
         - os: windows-latest
-          python-version: "3.10"
+          python-version: "3.11"
 
     steps:
       - name: Install hdf5 libs for Mac
         if: runner.os == 'macOS'
         run: brew install hdf5
+
+      - name: Install pyside2 for Windows
+        if: runner.os == 'Windows'
+        run: conda install -c conda-forge pyside2
 
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
   "pre-commit",
   "ruff",
   "setuptools_scm",
-  "pyside2",
+  "pyqt5",
   "imio",
 ]
 nb = ["jupyter", "k3d"]


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description
Switched out PySide2 for PyQt5 in the dev dependencies. This allows CI to run using windows python 3.11.

**What is this PR**
- [x] Other

**Why is this PR needed?**
There is no versions of PySide2 that's compatible with python 3.11 and Windows.

**What does this PR do?**
Changed PySide2 to PyQt5

## References
Closes #258 

## How has this PR been tested?
Tested locally and on CI

## Is this a breaking change?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
