### PR TITLE
Unpinned h5py version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "pandas",
-    "h5py<=3.9", # vedo requires hdf5 <=1.12.x but hdf5 is 1.14+ from h5py 3.10 onwards
+    "h5py",
     "vedo>=2023.5.0",
     "k3d",
     "imio",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

Compatiblity with [MorphIO v3.3.7](https://github.com/BlueBrain/MorphIO/releases/tag/v3.3.7)

- [x] Other

**Why is this PR needed?**
Windows tests were failing due to a MorphIO update.

**What does this PR do?**
Unpin h5py from <=3.9.0 to ensure the correct hdf5 version is installed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
