### PR TITLE
fix some vedo function calls still using lowerCamelCase instead of snake_case

### DIFF
--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -128,7 +128,7 @@ class Actor:
             )  # pragma: no cover
 
         # some attributes should be from .mesh, others from ._mesh
-        mesh_attributes = ("centerOfMass",)
+        mesh_attributes = ("center_of_mass",)
         if attr in mesh_attributes:
             if hasattr(self.__dict__["mesh"], attr):
                 return getattr(self.__dict__["mesh"], attr)

--- a/brainrender/actors/ruler.py
+++ b/brainrender/actors/ruler.py
@@ -67,7 +67,7 @@ def ruler_from_surface(
     p2 = p1.copy()
     p2[axis] = 0  # zero the chosen coordinate
 
-    pts = root._mesh.intersect_with_line(p1, p2)
+    pts = root.mesh.intersect_with_line(p1, p2)
     surface_point = pts[0]
 
     return ruler(p1, surface_point, unit_scale=unit_scale, units=units, s=s)

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -119,8 +119,8 @@ class Render:
 
         Once an actor is 'corrected' it spawns labels and silhouettes as needed
         """
-        # don't apply transforms to points density actors or rulers
-        if isinstance(actor, PointsDensity) or actor.br_class == "Ruler":
+        # don't apply transforms to points density actors
+        if isinstance(actor, PointsDensity):
             logger.debug(
                 f'Not transforming actor "{actor.name} (type: {actor.br_class})"'
             )

--- a/brainrender/scene.py
+++ b/brainrender/scene.py
@@ -304,7 +304,7 @@ class Scene(JupyterMixIn, Render):
                 actors.cap()
             else:
                 for actor in actors:
-                    actor._mesh.cutWithPlane(
+                    actor._mesh.cut_with_plane(
                         origin=plane.center,
                         normal=plane.normal,
                     )

--- a/paper/figures/__init__.py
+++ b/paper/figures/__init__.py
@@ -20,7 +20,7 @@ def root_box(scene):
     of a brainrender region. This forces the camera to stay in place
     even if the root mesh is changed (e.g. sliced)
     """
-    pos = scene.root.centerOfMass()
+    pos = scene.root.center_of_mass()
     bounds = scene.root.bounds()
     bds = [
         bounds[1] - bounds[0],

--- a/paper/figures/zfish_neurons.py
+++ b/paper/figures/zfish_neurons.py
@@ -54,7 +54,7 @@ for neu_dict, neu in track(neurons, total=N):
     neuron = scene.add(neu_dict["axon"], alpha=1, color=col)
 
     soma = scene.add(
-        Point(neu_dict["soma"].centerOfMass(), color=col, radius=8, alpha=1)
+        Point(neu_dict["soma"].center_of_mass(), color=col, radius=8, alpha=1)
     )
     scene.add_silhouette(soma)
 


### PR DESCRIPTION
6a7ca30 should have probably updated `centerOfMass` to `center_of_mass` in the whitelisted attributes of `Actor.__getattr__()`