### PR TITLE
Add explicit `brainglobe-space` dependency

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,10 +3,18 @@ name: tests
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
-      - '*'
+      - 'v**'
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Cancel this workflow if it is running,
+  # and then changes are applied on top of the HEAD of the branch,
+  # triggering another run of the workflow
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:

--- a/examples/user_volumetric_data.py
+++ b/examples/user_volumetric_data.py
@@ -25,7 +25,7 @@ except ImportError:
 from pathlib import Path
 import pooch
 
-from bg_space import AnatomicalSpace
+from brainglobe_space import AnatomicalSpace
 from myterial import blue_grey, orange
 from rich import print
 from vedo import Volume as VedoVolume
@@ -69,7 +69,7 @@ scene = Scene(atlas_name="mpin_zfish_1um")
 
 source_space = AnatomicalSpace(
     "ira"
-)  # for more info: https://docs.brainglobe.info/bg-space/usage
+)  # for more info: https://docs.brainglobe.info/brainglobe-space/usage
 target_space = scene.atlas.space
 transformed_stack = source_space.map_stack_to(target_space, data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,34 @@
 [project]
 name = "brainrender"
-authors = [{name = "Federico Claudi, Adam Tyson, Luigi Petrucco", email="hello@brainglobe.info"}]
+authors = [
+    { name = "Federico Claudi, Adam Tyson, Luigi Petrucco", email = "hello@brainglobe.info" },
+]
 description = "Visualisation and exploration of brain atlases and other anatomical data"
 readme = "README.md"
 requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 dependencies = [
+    "bg-atlasapi>=1.0.0",
+    "brainglobe-space>=1.0.0",
+    "h5py",
+    "imio",
+    "k3d",
+    "loguru",
+    "morphapi>=0.2.1",
+    "msgpack",
+    "myterial",
     "numpy",
     "pandas",
-    "h5py",
-    "vedo>=2023.5.0",
-    "k3d",
-    "imio",
-    "msgpack",
-    "pyyaml>=5.3",
     "pooch",
-    "morphapi>=0.2.1",
-    "requests",
-    "bg-atlasapi>=1.0.0",
-    "tables",
     "pyinspect>=0.0.8",
-    "myterial",
-    "loguru",
+    "pyyaml>=5.3",
+    "requests",
+    "tables",
+    "vedo>=2023.5.0",
 ]
 
-license = {text = "BSD-3-Clause"}
+license = { text = "BSD-3-Clause" }
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
@@ -48,26 +51,22 @@ Documentation = "https://brainglobe.info/documentation/brainrender/index.html"
 
 [project.optional-dependencies]
 dev = [
-  "pytest",
-  "pytest-cov",
-  "coverage",
-  "tox",
-  "black",
-  "mypy",
-  "pre-commit",
-  "ruff",
-  "setuptools_scm",
-  "imio",
+    "pytest",
+    "pytest-cov",
+    "coverage",
+    "tox",
+    "black",
+    "mypy",
+    "pre-commit",
+    "ruff",
+    "setuptools_scm",
+    "imio",
 ]
 nb = ["jupyter", "k3d"]
 
 
 [build-system]
-requires = [
-    "setuptools>=45",
-    "wheel",
-    "setuptools_scm[toml]>=6.2",
-]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -94,19 +93,19 @@ line-length = 79
 
 [tool.check-manifest]
 ignore = [
-  ".yaml",
-  "tox.ini",
-  "tests/",
-  "tests/test_unit/",
-  "tests/test_integration/",
-  "docs/",
-  "docs/source/",
+    ".yaml",
+    "tox.ini",
+    "tests/",
+    "tests/test_unit/",
+    "tests/test_integration/",
+    "docs/",
+    "docs/source/",
 ]
 
 # should revisit some of these.
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs","examples"]
+exclude = ["__init__.py", "build", ".eggs", "examples"]
 select = ["I", "E", "F"]
 fix = true
 ignore = ["E501", "E402"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,7 @@ import imio
 import numpy as np
 import pooch
 import pytest
-from bg_space import AnatomicalSpace
+from brainglobe_space import AnatomicalSpace
 from vedo import Volume as VedoVolume
 
 from brainrender import Animation, Scene, VideoMaker


### PR DESCRIPTION
See https://github.com/brainglobe/brainglobe-space/issues/37

We also were not depending on `bg-space` in our pyproject but were saved by it's implicit fetch from `morphapi`, but now we will depend on `brainglobe-space` as an insurance.

New version upon merging will be 2.1.5.

Currently we are experiencing #322 which is a blocker. Investigating.