### PR TITLE
User-specified colormap in PointsDensity

### DIFF
--- a/brainrender/actors/points.py
+++ b/brainrender/actors/points.py
@@ -113,13 +113,20 @@ class Points(PointsBase, Actor):
 
 class PointsDensity(Actor):
     def __init__(
-        self, data, name=None, dims=(40, 40, 40), radius=None, **kwargs
+        self,
+        data,
+        name=None,
+        dims=(40, 40, 40),
+        radius=None,
+        colors="Dark2",
+        **kwargs,
     ):
         """
         Creates a Volume actor showing the 3d density of a set
         of points.
 
         :param data: np.ndarray, Nx3 array with cell coordinates
+        :param colors: str, matplotlib colormap
 
 
         from vedo:
@@ -140,7 +147,7 @@ class PointsDensity(Actor):
         volume = (
             vPoints(data)
             .density(dims=dims, radius=radius, **kwargs)
-            .cmap("Dark2")
+            .cmap(colors)
             .alpha([0, 0.9])
             .mode(1)
         )  # returns a vedo Volume


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
NA

**What does this PR do?**
Allows the user to specify a colormap for the points density feature.

## References

https://github.com/brainglobe/brainrender/issues/323

## How has this PR been tested?

I ran [examples/cell_density.py](https://github.com/brainglobe/brainrender/blob/main/examples/cell_density.py) example, https://github.com/brainglobe/brainrender/blob/980a76fee9796595561f99e760083cafea09f62d/examples/cell_density.py#L42

using `scene.add(PointsDensity(coordinates, colors="inferno"))` instead.

## Is this a breaking change?

I hope not

## Does this PR require an update to the documentation?

The PointsDensity is not documented in the documentation, so NA. We could add the colormap option in the example.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)

## Notes
I'm unfamiliar with (read : I don't know anything about) tests and pre-commits, so I didn't do those. I used ruff to format my addition in VSCode, but that's about it.