### PR TITLE
Added support for multiple screenshot file formats

### DIFF
--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -347,9 +347,11 @@ class Render:
             self.render(interactive=False)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        name = name or f"brainrender_screenshot_{timestamp}"
-        if ".png" not in name:
-            name += ".png"
+        name = Path(name or f"brainrender_screenshot_{timestamp}")
+
+        # If no suffix is provided or it an unsupported format, default to .png
+        if name.suffix not in [".png", ".eps", ".pdf", ".svg", ".jpg"]:
+            name = name.with_suffix(".png")
 
         scale = scale or settings.SCREENSHOT_SCALE
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -102,7 +102,8 @@ def test_scene_slice():
 
 
 @pytest.mark.parametrize(
-    "name, scale, expected_suffix", [
+    "name, scale, expected_suffix",
+    [
         ("test", 2, ".png"),
         (None, None, ".png"),
         (None, 1, ".png"),
@@ -112,13 +113,22 @@ def test_scene_slice():
         ("test.svg", 1, ".svg"),
         ("test.pdf", 1, ".pdf"),
         ("test.tiff", 1, ".png"),
-    ]
+    ],
 )
 def test_scene_screenshot(name, scale, expected_suffix):
     screenshot_folder = Path.home() / "test_screenshots"
     s = Scene(screenshots_folder=screenshot_folder)
     out_path = s.screenshot(name=name, scale=scale)
+
     assert Path(out_path).suffix == expected_suffix
+
+    # Vedo exports eps and svg files as gzipped files
+    # Append the .gz suffix to the expected path to check if file exists
+    if expected_suffix in [".eps", ".svg"]:
+        out_path += ".gz"
+
+    assert Path(out_path).exists()
+
     shutil.rmtree(screenshot_folder)
     del s
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -101,12 +102,24 @@ def test_scene_slice():
 
 
 @pytest.mark.parametrize(
-    "name, scale", [("test", 2), (None, None), (None, 1), ("test2", None)]
+    "name, scale, expected_suffix", [
+        ("test", 2, ".png"),
+        (None, None, ".png"),
+        (None, 1, ".png"),
+        ("test2", None, ".png"),
+        ("test.jpg", 1, ".jpg"),
+        ("test.eps", 1, ".eps"),
+        ("test.svg", 1, ".svg"),
+        ("test.pdf", 1, ".pdf"),
+        ("test.tiff", 1, ".png"),
+    ]
 )
-def test_scene_screenshot(name, scale):
-    s = Scene(screenshots_folder="tests/screenshots")
-    s.screenshot(name=name, scale=scale)
-    shutil.rmtree("tests/screenshots")
+def test_scene_screenshot(name, scale, expected_suffix):
+    screenshot_folder = Path.home() / "test_screenshots"
+    s = Scene(screenshots_folder=screenshot_folder)
+    out_path = s.screenshot(name=name, scale=scale)
+    assert Path(out_path).suffix == expected_suffix
+    shutil.rmtree(screenshot_folder)
     del s
 
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently we only support saving screenshots as `.png`. `vedo` seems to support `.pdf`, `.eps`, `.jpg`, and `.svg`. I don't see why we couldn't as well!

**What does this PR do?**
Adds a check to make sure the suffix of the file name is supported before passing it back to `vedo`. If there's no suffix, or it's not supported it just saves it as a `.png`.

## References
Closes #340 

## How has this PR been tested?
Tested locally

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Yes, need to document the supported file formats. There are seems to be some weird behaviour when saving as `.eps` or `.svg` where they're written as `.eps.gz` or `.svg.gz` and have to be uncompressed first. 

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
