### PR TITLE
CI for both Mac architectures

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,10 +48,6 @@ jobs:
           python-version: "3.11"
 
     steps:
-      - name: Install hdf5 libs for Mac
-        if: runner.os == 'macOS'
-        run: brew install hdf5
-
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -53,7 +53,12 @@ jobs:
 
       # Sets up ffmpeg to we can run video tests on CI
       - uses: FedericoCarboni/setup-ffmpeg@v2
+        if: matrix.os != 'macos-latest'
         id: setup-ffmpeg
+
+      - name: setup ffmpeg on latest Mac with brew
+        if: matrix.os == 'macos-latest'
+        run: brew install ffmpeg
 
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,6 +48,10 @@ jobs:
           python-version: "3.11"
 
     steps:
+      - name: Install hdf5 libs for Mac
+        if: runner.os == 'macOS'
+        run: brew install hdf5
+
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,8 +38,10 @@ jobs:
         # Run all supported Python versions on linux
         python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
-        # Include one windows and macos run
+        # Include one windows and macos run each of Intel/ARM
         include:
+        - os: macos-13
+          python-version: "3.11"
         - os: macos-latest
           python-version: "3.11"
         - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "msgpack",
     "myterial",
     "numpy",
-    "pandas[hdf5]",
+    "pandas",
     "pooch",
     "pyinspect>=0.0.8",
     "pyyaml>=5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "msgpack",
     "myterial",
     "numpy",
-    "pandas",
+    "pandas[hdf5]",
     "pooch",
     "pyinspect>=0.0.8",
     "pyyaml>=5.3",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We'd like to run CI on both Intel and Silicon Macs.

**What does this PR do?**

This PR modifies the workflow file so that test and installation runs smoothly on both Mac architectures.

## References
Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

## How has this PR been tested?

CI runs observed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
