### PR TITLE
Update from imio to brainglobe_utils.IO.image

### DIFF
--- a/examples/user_volumetric_data.py
+++ b/examples/user_volumetric_data.py
@@ -15,27 +15,19 @@
 
 """
 
-try:
-    import imio
-except ImportError:
-    raise ImportError(
-        'You need imio to run this example: "pip install imio".\nFor more details: https://github.com/brainglobe/imio'
-    )
-
 from pathlib import Path
 import pooch
 
 from brainglobe_space import AnatomicalSpace
+from brainglobe_utils.IO.image.load import load_any
 from myterial import blue_grey, orange
 from rich import print
 from vedo import Volume as VedoVolume
 
 from brainrender import Scene
-from brainrender.actors import Volume
 
 print(f"[{orange}]Running example: {Path(__file__).name}")
 
-# specify where the data are saved
 
 retrieved_paths = pooch.retrieve(
     url="https://api.mapzebrain.org/media/Lines/brn3cGFP/average_data/T_AVG_s356tTg.zip",
@@ -51,17 +43,12 @@ retrieved_paths = pooch.retrieve(
     ),
 )
 
-datafile = Path(retrieved_paths[1])  # [0] is zip file
-
-if not datafile.exists():
-    raise ValueError(
-        "Before running this example you need to download the data for gene expression of the line brn3c:GFP from https://fishatlas.neuro.mpg.de/lines/"
-    )
+datafile = Path(retrieved_paths[0])  # [0] is zip file
 
 
 # 1. load the data
 print("Loading data")
-data = imio.load.load_any(datafile)
+data = load_any(datafile)
 
 # 2. aligned the data to the scene's atlas' axes
 print("Transforming data")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dynamic = ["version"]
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
     "brainglobe-space>=1.0.0",
+    "brainglobe-utils>0.5.0",
     "h5py",
     "imio",
     "k3d",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
     "brainglobe-space>=1.0.0",
-    "brainglobe-utils>0.5.0",
+    "brainglobe-utils>=0.5.0",
     "h5py",
     "imio",
     "k3d",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,11 @@
 from importlib.resources import files
 from pathlib import Path
 
-import imio
 import numpy as np
 import pooch
 import pytest
 from brainglobe_space import AnatomicalSpace
+from brainglobe_utils.IO.image.load import load_any
 from vedo import Volume as VedoVolume
 
 from brainrender import Animation, Scene, VideoMaker
@@ -318,8 +318,8 @@ def test_user_volumetric_data():
         ),
     )
 
-    datafile = Path(retrieved_paths[1])  # [0] is zip file
-    data = imio.load.load_any(datafile)
+    datafile = Path(retrieved_paths[0])
+    data = load_any(datafile)
     source_space = AnatomicalSpace("ira")
     target_space = scene.atlas.space
     transformed_data = source_space.map_stack_to(target_space, data)


### PR DESCRIPTION
This was meant to be a follow on from https://github.com/brainglobe/brainglobe-utils/pull/73, but the use in brainrender was so out of date, it's essentially independent. However, this PR reflects the latest API, so needs https://github.com/brainglobe/brainglobe-utils/pull/73 to pass. It will also [need a new version of vedo too](https://github.com/marcomusy/vedo/issues/1117), but that issue is unrelated to this PR.

I also updated this example slightly and removed some unnecessary code. 