### PR TITLE
Fix camera position setting

### DIFF
--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -227,7 +227,7 @@ class Render:
             camera["focal_point"] = self.root._mesh.center_of_mass()
 
         if not self.backend and camera is not None:
-            _ = set_camera(self, camera)
+            camera = set_camera(self, camera)
 
         # Apply axes correction
         for actor in self.clean_actors:
@@ -266,6 +266,7 @@ class Render:
                 bg=settings.BACKGROUND_COLOR,
                 rate=40,
                 axes=self.plotter.axes,
+                resetcam=False,
             )
         elif self.backend == "k3d":  # pragma: no cover
             # Remove silhouettes

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -227,7 +227,7 @@ class Render:
             camera["focal_point"] = self.root._mesh.center_of_mass()
 
         if not self.backend and camera is not None:
-            camera = set_camera(self, camera)
+            _ = set_camera(self, camera)
 
         # Apply axes correction
         for actor in self.clean_actors:


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The camera position was not set properly when passing a custom camera dict to `scene.render`. 

**What does this PR do?**
Passes `resetcam=False` back to `plotter.show`. Without this the camera position was being [adjusted](https://github.com/marcomusy/vedo/blob/afdade4e1b89ecc7e960121780889f39d3ca8d7d/vedo/plotter.py#L3346-L3347) in the `plotter.show` method.

## References
Closes #360 

## How has this PR been tested?
All tests pass, running the workflow as stated in the bug report also works. Can adjust the camera and position, save the output from Shift+C, and recreate the exact camera position with a dict.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
