### PR TITLE
Remove unused camera printing code and make camera parameters consistent

### DIFF
--- a/brainrender/camera.py
+++ b/brainrender/camera.py
@@ -17,7 +17,7 @@ def check_camera_param(camera):
     """
     Check that a dictionary of camera parameters
     is complete. Must have entries:
-    ["position", "focal", "viewup", "distance", "clipping"]
+    ["pos", "viewup", "clipping_range"]
 
     :param camera: str, dict
     """
@@ -106,6 +106,5 @@ def get_camera_params(scene=None, camera=None):
         viewup=clean(cam.GetViewUp()),
         distance=clean(cam.GetDistance()),
         clipping_range=clean(cam.GetClippingRange()),
-        # orientation=clean(cam.GetOrientation()),
     )
     return params

--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 from loguru import logger
-from myterial import amber, deep_purple_light, orange, teal
+from myterial import teal
 from rich import print
 from rich.syntax import Syntax
 from vedo import Plotter
@@ -15,7 +15,6 @@ from brainrender.actors.points import PointsDensity
 from brainrender.camera import (
     check_camera_param,
     get_camera,
-    get_camera_params,
     set_camera,
 )
 
@@ -360,27 +359,6 @@ class Render:
         self.plotter.screenshot(filename=savepath, scale=scale)
         return savepath
 
-    def _print_camera(self):
-        pms = get_camera_params(scene=self)
-
-        focal = pms.pop("focal_point", None)
-        dst = pms.pop("distance", None)
-
-        names = [
-            f"[green bold]     '{k}'[/green bold]: [{amber}]{v},"
-            for k, v in pms.items()
-        ]
-        print(
-            f"[{deep_purple_light}]Camera parameters:",
-            f"[{orange}]    {{",
-            *names,
-            f"[{orange}]   }}",
-            f"[{deep_purple_light}]Additional, (optional) parameters:",
-            f"[green bold]     'focal_point'[/green bold]: [{amber}]{focal},",
-            f"[green bold]     'distance'[/green bold]: [{amber}]{dst},",
-            sep="\n",
-        )
-
     def keypress(self, key):  # pragma: no cover
         """
         Handles key presses for interactive view
@@ -393,6 +371,3 @@ class Render:
 
         elif key in ("q", "Esc"):
             self.close()
-
-        elif key == "c":
-            self._print_camera()


### PR DESCRIPTION
Reviewing #360 I noticed that the camera parameters that brainrender checks don't exactly match the parameters that the user that it must have. This corrects that. 

I then noticed that the code that prints the camera position isn't actually used (vedo uses the same keyboard shortcut), so I removed it. I raised https://github.com/marcomusy/vedo/pull/1134 to correct the parameters that are printed. 