### PR TITLE
Mark tests that are expected to fail with `xfail` rather than just not running them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ brainrender/atlas_specific/gene_expression/__pycache__/*
 brainrender/atlas_specific/__pycache__
 
 example_brainrender_shot*
-
+brain_regions.html
 workspace.py
 workspace.ipynb
 brexport.html

--- a/tests/test_streamlines.py
+++ b/tests/test_streamlines.py
@@ -1,33 +1,36 @@
-# import pandas as pd
-# import pytest
-#
-# from brainrender import Scene
-# from brainrender.actors.streamlines import (
-#     Streamlines,
-#     make_streamlines,
-# )
-# from brainrender.atlas_specific import get_streamlines_for_region
-#
-#
-# def test_download():
-#     streams = get_streamlines_for_region("TH", force_download=False)
-#     assert len(streams) == 54
-#     assert isinstance(streams[0], pd.DataFrame)
-#
-#
-# def test_download_slow():
-#     streams = get_streamlines_for_region("TH", force_download=True)
-#     assert len(streams) == 54
-#     assert isinstance(streams[0], pd.DataFrame)
-#
-#
-# def test_streamlines():
-#     s = Scene(title="BR")
-#     streams = get_streamlines_for_region("TH", force_download=False)
-#     s.add(Streamlines(streams[0]))
-#     s.add(*make_streamlines(*streams[1:3]))
-#
-#     with pytest.raises(TypeError):
-#         Streamlines([1, 2, 3])
-#
-#     del s
+import pandas as pd
+import pytest
+
+from brainrender import Scene
+from brainrender.actors.streamlines import (
+    Streamlines,
+    make_streamlines,
+)
+from brainrender.atlas_specific import get_streamlines_for_region
+
+
+@pytest.mark.xfail(reason="Likely due to fail due to neuromorpho")
+def test_download():
+    streams = get_streamlines_for_region("TH", force_download=False)
+    assert len(streams) == 54
+    assert isinstance(streams[0], pd.DataFrame)
+
+
+@pytest.mark.xfail(reason="Likely due to fail due to neuromorpho")
+def test_download_slow():
+    streams = get_streamlines_for_region("TH", force_download=True)
+    assert len(streams) == 54
+    assert isinstance(streams[0], pd.DataFrame)
+
+
+@pytest.mark.xfail(reason="Likely due to fail due to neuromorpho")
+def test_streamlines():
+    s = Scene(title="BR")
+    streams = get_streamlines_for_region("TH", force_download=False)
+    s.add(Streamlines(streams[0]))
+    s.add(*make_streamlines(*streams[1:3]))
+
+    with pytest.raises(TypeError):
+        Streamlines([1, 2, 3])
+
+    del s


### PR DESCRIPTION
At least this way we will know whether or not they are passing. 