### PR TITLE
Remove duplicated help information

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ From PyPI:
 pip install brainrender
 ```
 
-If you encounter any issues, please ask a question on the [image.sc forum](https://forum.image.sc/tag/brainglobe) tagging your question with `brainglobe`.
-
-
 ## Quickstart
 
 ``` python


### PR DESCRIPTION
To ensure people can easily find the most appropriate places to seek help, we've decided to have one link to the contact page on each repo. I missed this stray link previously. 