### PR TITLE
Update hemisphere slicing

### DIFF
--- a/brainrender/scene.py
+++ b/brainrender/scene.py
@@ -288,13 +288,11 @@ class Scene(JupyterMixIn, Render):
 
         # slice to keep only one hemisphere
         if hemisphere == "right":
-            plane = self.atlas.get_plane(
-                pos=self.root._mesh.center_of_mass(), norm=(0, 0, 1)
-            )
+            mesh_center = self.root._mesh.bounds().reshape((3, 2)).mean(axis=1)
+            plane = self.atlas.get_plane(pos=mesh_center, norm=(0, 0, 1))
         elif hemisphere == "left":
-            plane = self.atlas.get_plane(
-                pos=self.root._mesh.center_of_mass(), norm=(0, 0, -1)
-            )
+            mesh_center = self.root._mesh.bounds().reshape((3, 2)).mean(axis=1)
+            plane = self.atlas.get_plane(pos=mesh_center, norm=(0, 0, -1))
 
         if hemisphere in ("left", "right"):
             if not isinstance(actors, list):

--- a/brainrender/scene.py
+++ b/brainrender/scene.py
@@ -287,14 +287,17 @@ class Scene(JupyterMixIn, Render):
         actors = self.add(*regions)
 
         # slice to keep only one hemisphere
-        if hemisphere == "right":
-            mesh_center = self.root._mesh.bounds().reshape((3, 2)).mean(axis=1)
-            plane = self.atlas.get_plane(pos=mesh_center, norm=(0, 0, 1))
-        elif hemisphere == "left":
-            mesh_center = self.root._mesh.bounds().reshape((3, 2)).mean(axis=1)
-            plane = self.atlas.get_plane(pos=mesh_center, norm=(0, 0, -1))
-
         if hemisphere in ("left", "right"):
+            if self.atlas.metadata["symmetric"]:
+                mesh_center = (
+                    self.root._mesh.bounds().reshape((3, 2)).mean(axis=1)
+                )
+            else:
+                mesh_center = self.root._mesh.center_of_mass()
+
+            normal = (0, 0, 1) if hemisphere == "right" else (0, 0, -1)
+            plane = self.atlas.get_plane(pos=mesh_center, norm=normal)
+
             if not isinstance(actors, list):
                 actors._mesh.cut_with_plane(
                     origin=plane.center,


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See the discussion in https://github.com/brainglobe/brainglobe-atlasapi/issues/330

**What does this PR do?**
If the atlas is marked as symmetrical in the metadata the midpoint is now calculated by taking the mean of the root mesh bounds for each axis. If the atlas isn't marked as symmetrical the previous behaviour is maintained.

## References
https://github.com/brainglobe/brainglobe-atlasapi/issues/330

## How has this PR been tested?
Tested locally by visual inspection.
For an asymmetric atlas:
```
scene = Scene(atlas_name="mpin_zfish_1um")
scene.add_brain_region("hindbrain", hemisphere="right")
scene.add_brain_region("forebrain", hemisphere="left")
scene.render()
```

For symmetric atlases:
```
scene = Scene(atlas_name="allen_cord_20um")
scene.add_brain_region("WM", hemisphere="left")
scene.render()
```

```
scene = Scene(atlas_name="allen_mouse_25um")
scene.add_brain_region("CTX", hemisphere="left")
scene.render()
```

## Is this a breaking change?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
