### PR TITLE
Added an example to dynamically alter the scene in each frame

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,10 @@ repos:
           - id: requirements-txt-fixer
           - id: trailing-whitespace
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.5.0
+      rev: v0.5.6
       hooks:
         - id: ruff
     - repo: https://github.com/psf/black
-      rev: 24.4.2
+      rev: 24.8.0
       hooks:
           - id: black

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -134,6 +134,9 @@ class VideoMaker:
             if not first_frame:
                 logger.error("No keyframes found, can't fix camera")
 
+            # Sets the focal point of the first frame to the centre of mass of the
+            # full root mesh, since this focal point is set subsequent frames will
+            # have the same focal point unless a new camera is defined
             self.keyframes[0]["camera"][
                 "focal_point"
             ] = self.scene.root._mesh.center_of_mass()

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -121,6 +121,7 @@ class VideoMaker:
         :param duration: float, duration of the video in seconds
         :param fps: int, frame rate
         :param fix_camera: bool, if True the focal point of the camera is set based on the first frame
+        :param render_kwargs: dict, any extra keyword argument to be passed to `scene.render`
         :param **kwargs: any extra keyword argument to be passed to `make_frame_func`
         """
         logger.debug(f"Saving a video {duration}s long ({fps} fps)")

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -106,21 +106,37 @@ class VideoMaker:
 
     @not_on_jupyter
     def make_video(
-        self, *args, duration=10, fps=30, render_kwargs={}, **kwargs
+        self,
+        *args,
+        duration=10,
+        fps=30,
+        fix_camera=False,
+        render_kwargs={},
+        **kwargs,
     ):
         """
         Creates a video using user defined parameters
 
-        :param *args: any extra argument to be bassed to `make_frame_func`
-        :param duration: float, duratino of the video in seconds
+        :param *args: any extra argument to be passed to `make_frame_func`
+        :param duration: float, duration of the video in seconds
         :param fps: int, frame rate
-        :param **kwargs: any extra keyword argument to be bassed to `make_frame_func`
+        :param fix_camera: bool, if True the focal point of the camera is set based on the first frame
+        :param **kwargs: any extra keyword argument to be passed to `make_frame_func`
         """
         logger.debug(f"Saving a video {duration}s long ({fps} fps)")
         _off = br.settings.OFFSCREEN
         br.settings.OFFSCREEN = True  # render offscreen
 
         self.scene.render(interactive=False, **render_kwargs)
+
+        if fix_camera:
+            first_frame = self.keyframes.get(0)
+            if not first_frame:
+                logger.error("No keyframes found, can't fix camera")
+
+            self.keyframes[0]["camera"][
+                "focal_point"
+            ] = self.scene.root._mesh.center_of_mass()
 
         # cd to folder where the video will be saved
         curdir = os.getcwd()
@@ -317,7 +333,6 @@ class Animation(VideoMaker):
         elif frame_number > self.last_keyframe:
             # check if current frame is past the last keyframe
             params = self.keyframes[self.last_keyframe]
-            params["callback"] = None
 
         else:
             # interpolate between two key frames

--- a/examples/animation_callback.py
+++ b/examples/animation_callback.py
@@ -20,9 +20,9 @@ scene.add_brain_region(*regions, silhouette=True)
 def slc(scene, framen, totframes):
     # Get new slicing plane
     fact = framen / totframes
-    shape = list(scene.atlas.shape_um)
+    shape_um = scene.atlas.shape_um
     # Multiply by fact to move the plane, add buffer to go past the brain
-    point = [(shape[0] + 500) * fact, shape[1] // 2, shape[2] // 2]
+    point = [(shape_um[0] + 500) * fact, shape_um[1] // 2, shape_um[2] // 2]
     plane = scene.atlas.get_plane(pos=point, norm=(1, 0, 0))
 
     scene.slice(plane)

--- a/examples/animation_callback.py
+++ b/examples/animation_callback.py
@@ -1,0 +1,39 @@
+from brainrender import Animation, Scene, settings
+from pathlib import Path
+
+settings.SHOW_AXES = False
+
+scene = Scene(atlas_name="allen_mouse_25um")
+
+regions = (
+    "CTX",
+    "HPF",
+    "STR",
+    "CB",
+    "MB",
+    "TH",
+    "HY",
+)
+scene.add_brain_region(*regions, silhouette=True)
+
+
+def slc(scene, framen, totframes):
+    # Get new slicing plane
+    fact = framen / totframes
+    shape = list(scene.atlas.shape_um)
+    # Multiply by fact to move the plane, add buffer to go past the brain
+    point = [(shape[0] + 500) * fact, shape[1] // 2, shape[2] // 2]
+    plane = scene.atlas.get_plane(pos=point, norm=(1, 0, 0))
+
+    scene.slice(plane)
+
+
+anim = Animation(
+    scene, Path.cwd(), "brainrender_animation_callback", size=None
+)
+
+# Specify camera pos and zoom at some key frames`
+anim.add_keyframe(0, camera="frontal", zoom=1, callback=slc)
+
+# Make videos
+anim.make_video(duration=5, fps=10, fix_camera=True)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See https://forum.image.sc/t/brainrender-animation-of-slices/100612

**What does this PR do?**
Adds a new flag to `make_video` to fix the camera to the perspective of the first frame. Otherwise, if the root mesh is sliced throughout the animation the perspective will shift as the centre of mass of the root volume shifts.

Passes the callback function to subsequent frames after the last frame.

Adds an example for how to use a callback function to dynamically alter the scene throughout the Animation.

## How has this PR been tested?
All tests pass locally.

## Is this a breaking change?
No, the new flag is optional and the default provides the previous behaviour.

## Does this PR require an update to the documentation?
Yes, will come in subsequent PR.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
