### PR TITLE
remove `imio` from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "brainglobe-space>=1.0.0",
     "brainglobe-utils>=0.5.0",
     "h5py",
-    "imio",
     "k3d",
     "loguru",
     "morphapi>=0.2.1",
@@ -61,7 +60,6 @@ dev = [
     "pre-commit",
     "ruff",
     "setuptools_scm",
-    "imio",
 ]
 nb = ["jupyter", "k3d"]
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We still depend on (the archived and obsolete) `imio` in `pyproject.toml`,
but it's not used anywhere, since https://github.com/brainglobe/brainrender/pull/346.
 
**What does this PR do?**
Remove `imio` from dependencies in `pyproject.toml`

## References

Closes #384 

## How has this PR been tested?

Double-checked that CI passes.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

