### PR TITLE
Expose resetcam parameter 

### DIFF
--- a/brainrender/render.py
+++ b/brainrender/render.py
@@ -191,6 +191,7 @@ class Render:
         interactive=None,
         camera=None,
         zoom=None,
+        resetcam=False,
         **kwargs,
     ):
         """
@@ -203,6 +204,7 @@ class Render:
             Pass a valid camera input to specify the camera position when
             the scene is rendered.
         :param zoom: float, if None atlas default is used
+        :param resetcam: bool, if True the camera is reset between renders
         :param kwargs: additional arguments to pass to self.plotter.show
         """
         logger.debug(
@@ -265,7 +267,7 @@ class Render:
                 bg=settings.BACKGROUND_COLOR,
                 rate=40,
                 axes=self.plotter.axes,
-                resetcam=False,
+                resetcam=resetcam,
             )
         elif self.backend == "k3d":  # pragma: no cover
             # Remove silhouettes

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -57,7 +57,13 @@ class VideoMaker:
 
     @staticmethod
     def _make_frame(
-        scene, frame_number, tot_frames, azimuth=0, elevation=0, roll=0
+        scene,
+        frame_number,
+        tot_frames,
+        resetcam,
+        azimuth=0,
+        elevation=0,
+        roll=0,
     ):
         """
         Default `make_frame_func`. Rotates the camera in 3 directions
@@ -65,6 +71,7 @@ class VideoMaker:
         :param scene: scene to be animated.
         :param frame_number: int, not used
         :param tot_frames: int, total number of frames
+        :param resetcam: bool, if True the camera is reset
         :param azimuth: integer, specify the rotation in degrees
                     per frame on the relative axis. (Default value = 0)
         :param elevation: integer, specify the rotation in degrees
@@ -72,22 +79,25 @@ class VideoMaker:
         :param roll: integer, specify the rotation in degrees
                     per frame on the relative axis. (Default value = 0)
         """
-        scene.plotter.show(interactive=False)
+        scene.plotter.show(interactive=False, resetcam=resetcam)
         scene.plotter.camera.Elevation(elevation)
         scene.plotter.camera.Azimuth(azimuth)
         scene.plotter.camera.Roll(roll)
 
-    def generate_frames(self, fps, duration, video, *args, **kwargs):
+    def generate_frames(self, fps, duration, video, resetcam, *args, **kwargs):
         """
         Loop to generate frames
 
         :param fps: int, frame rate
         :param duration: float, video duration in seconds
         :param video: vedo Video class used to create the video
+        :param resetcam: bool, if True the camera is reset
         """
         nframes = int(fps * duration)
         for i in track(range(nframes), description="Generating frames"):
-            self.make_frame_func(self.scene, i, nframes, *args, **kwargs)
+            self.make_frame_func(
+                self.scene, i, nframes, resetcam, *args, **kwargs
+            )
             video.add_frame()
 
     def compress(self, temp_name):
@@ -111,6 +121,7 @@ class VideoMaker:
         duration=10,
         fps=30,
         fix_camera=False,
+        resetcam=False,
         render_kwargs={},
         **kwargs,
     ):
@@ -157,7 +168,7 @@ class VideoMaker:
         )
 
         # Make frames
-        self.generate_frames(fps, duration, video, *args, **kwargs)
+        self.generate_frames(fps, duration, video, resetcam * args, **kwargs)
         self.scene.close()
 
         # Stitch frames into uncompressed video
@@ -291,13 +302,14 @@ class Animation(VideoMaker):
         }
         self.keyframes_numbers = sorted(list(self.keyframes.keys()))
 
-    def generate_frames(self, fps, duration, video):
+    def generate_frames(self, fps, duration, video, resetcam):
         """
         Loop to generate frames
 
         :param fps: int, frame rate
         :param duration: float, video duration in seconds
         :param video: vedo Video class used to create the video
+        :param resetcam: bool, if True the camera is reset
         """
         logger.debug(
             f"Generating animation keyframes. Duration: {duration}, fps: {fps}"
@@ -315,7 +327,7 @@ class Animation(VideoMaker):
         for framen in track(
             range(self.nframes), description="Generating frames..."
         ):
-            self._make_frame(framen)
+            self._make_frame(framen, resetcam)
 
             if framen > 1:
                 video.add_frame()
@@ -359,7 +371,7 @@ class Animation(VideoMaker):
             params["camera"] = get_camera_params(self.scene)
         return params
 
-    def _make_frame(self, frame_number):
+    def _make_frame(self, frame_number, resetcam):
         """
         Creates a frame with the correct params
         and calls the keyframe callback function if defined.
@@ -388,7 +400,7 @@ class Animation(VideoMaker):
             camera=camera.copy(),
             zoom=frame_params["zoom"],
             interactive=False,
-            resetcam=False,
+            resetcam=resetcam,
         )
 
     def _interpolate_cameras(self, cam1, cam2):

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -132,6 +132,7 @@ class VideoMaker:
         :param duration: float, duration of the video in seconds
         :param fps: int, frame rate
         :param fix_camera: bool, if True the focal point of the camera is set based on the first frame
+        :param resetcam: bool, if True the camera is reset
         :param render_kwargs: dict, any extra keyword argument to be passed to `scene.render`
         :param **kwargs: any extra keyword argument to be passed to `make_frame_func`
         """
@@ -168,7 +169,7 @@ class VideoMaker:
         )
 
         # Make frames
-        self.generate_frames(fps, duration, video, resetcam * args, **kwargs)
+        self.generate_frames(fps, duration, video, resetcam, *args, **kwargs)
         self.scene.close()
 
         # Stitch frames into uncompressed video

--- a/examples/animation.py
+++ b/examples/animation.py
@@ -29,4 +29,4 @@ anim.add_keyframe(3, camera="frontal", zoom=1)
 anim.add_keyframe(4, camera="frontal", zoom=1.2)
 
 # Make videos
-anim.make_video(duration=5, fps=15)
+anim.make_video(duration=5, fps=15, resetcam=True)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Changing the zoom settings in the animation/video examples currently causes the camera to behave poorly.

**What does this PR do?**
Exposes the resetcam parameter in the `Animation`, and `VideoMaker` and sets it to `False` by default. If zoom is used `resetcam` can be set to `True` allowing the camera to behave appropriately.

## References
closes #377 
Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
All current tests pass, the `animation_callback.py`, `animation.py`, and `custom_camera.py` all run as expected.
#360 runs correctly as well.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
