### PR TITLE
Schedule weekly tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v**'
   pull_request:
+  schedule:
+  # Runs at 6am UTC every day
+    - cron: '10 6 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -8,7 +8,7 @@ on:
       - 'v**'
   pull_request:
   schedule:
-  # Runs at 6am UTC every day
+  # Runs at 6:10am UTC on Monday
     - cron: '10 6 * * 1'
   workflow_dispatch:
 


### PR DESCRIPTION
Schedule tests to run weekly to ensure no installation issues, and keep the cache fresh.