### PR TITLE
update tests and pyproject to latest vedo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pyyaml>=5.3",
     "requests",
     "tables",
-    "vedo>=2024.5.2",
+    "vedo>=2025.5.3",
     "vtk"
 ]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -221,10 +221,10 @@ def test_gene_expression(scene):
 
     scene.render(interactive=False)
 
-    # Expand bounds by 500 px
+    # Expand bounds by 600 px
     ca1_bounds = ca1.bounds()
     expanded_bounds = [
-        bound - 500 if i % 2 == 0 else bound + 500
+        bound - 600 if i % 2 == 0 else bound + 600
         for i, bound in enumerate(ca1_bounds)
     ]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,7 +32,7 @@ def get_n_points_in_region(region, N):
     Z = np.linspace(region_bounds[4], region_bounds[5], num=N)
     pts = [[x, y, z] for x, y, z in zip(X, Y, Z)]
 
-    ipts = region.mesh.inside_points(pts).points()
+    ipts = region.mesh.inside_points(pts).points
     return np.vstack(ipts)
 
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -22,7 +22,7 @@ def get_n_random_points_in_region(region, N):
     Z = np.random.randint(region_bounds[4], region_bounds[5], size=10000)
     pts = [[x, y, z] for x, y, z in zip(X, Y, Z)]
 
-    ipts = region.mesh.inside_points(pts).points()
+    ipts = region.mesh.inside_points(pts).points
     return np.vstack(random.choices(ipts, k=N))
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Scheduled tests failed, because of API changes in latest `vedo`

**What does this PR do?**
Update tests to match new API, and require latest vedo in `pyproject.toml`

Also, makes a bounds tests less strict - this is fine for our purposes, but worth flagging to @marcomusy that [the `gene` actor in `test_integration.py::test_gene_expression`](https://github.com/brainglobe/brainrender/blob/2496ab0bf80e48e28dd24b5293a0bb45f85242bf/tests/test_integration.py#L210) returns different bounds for `vedo` 2024.5.2 and 2025.5.2 - is this expected?

(output of a bash script that installs the `vedo` versions and then calls a Python script that prints the actor's bounds)
```Collecting vedo==2024.5.2
...
Installing collected packages: vedo
  Attempting uninstall: vedo
    Found existing installation: vedo 2025.5.3
    Uninstalling vedo-2025.5.3:
      Successfully uninstalled vedo-2025.5.3
Successfully installed **vedo-2024.5.2**
**gene bounds [ 6400.  9400.  1600.  6000. -9800. -1600.]**
...
Installing collected packages: vedo
  Attempting uninstall: vedo
    Found existing installation: vedo 2024.5.2
    Uninstalling vedo-2024.5.2:
      Successfully uninstalled vedo-2024.5.2
Successfully installed **vedo-2025.5.3**
**gene bounds [  6000.   9600.   1200.   6200. -10000.  -1400.]**
```