### PR TITLE
fix: update vedo configuration instructions

### DIFF
--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -46,6 +46,8 @@ class not_on_jupyter:  # pragma: no cover
                 f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook",
                 f"[{orange_dark}]Try setting the correct backend before creating your scene:\n",
                 Syntax("import vedo", lexer="python"),
-                Syntax("vedo.settings.default_backend = 'none'", lexer="python"),
+                Syntax(
+                    "vedo.settings.default_backend = 'none'", lexer="python"
+                ),
             )
             return None

--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -45,7 +45,7 @@ class not_on_jupyter:  # pragma: no cover
             print(
                 f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook",
                 f"[{orange_dark}]Try setting the correct backend before creating your scene:\n",
-                Syntax("from vedo import embedWindow", lexer="python"),
-                Syntax("embedWindow(None)", lexer="python"),
+                Syntax("import vedo", lexer="python"),
+                Syntax("vedo.settings.default_backend = 'none'", lexer="python"),
             )
             return None


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The error message in class not_on_jupyter decorator was referencing vedo.embedWindow which has been removed from the vedo library. This caused users to receive misleading instructions when attempting to run certain functions in Jupyter notebooks.

**What does this PR do?**
Updates the error message in _jupyter.py to show the correct way to configure vedo's backend in Jupyter notebooks. Specifically, it replaces the outdated suggestion to use embedWindow(None) with the proper approach of setting
(vedo.settings.default_backend = 'none)

## References
https://github.com/brainglobe/brainrender/issues/413


## How has this PR been tested?
Using pytest

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
