### PR TITLE
fix: replace removed embedWindow with correct vedo backend instructions

### DIFF
--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -43,7 +43,7 @@ class not_on_jupyter:  # pragma: no cover
             return self.func(obj, *args, **kwargs)
         else:
             print(
-                f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook.",
+                f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/bold {salmon}] in a jupyter notebook.",
                 f"[{orange_dark}]To use brainrender in a Jupyter notebook, set the vedo backend to 'k3d' before creating your scene:\n",
                 Syntax("import vedo", lexer="python"),
                 Syntax(

--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -44,8 +44,11 @@ class not_on_jupyter:  # pragma: no cover
         else:
             print(
                 f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook",
-                f"[{orange_dark}]Try setting the correct backend before creating your scene:\n",
-                Syntax("from vedo import embedWindow", lexer="python"),
-                Syntax("embedWindow(None)", lexer="python"),
+                f"[{orange_dark}]To use brainrender outside of a Jupyter notebook, set the vedo backend before creating your scene:\n",
+                Syntax("import vedo", lexer="python"),
+                Syntax("vedo.settings.default_backend = 'vtk'", lexer="python"),
+                f"[{orange_dark}]Or to embed the scene inside the notebook, use the k3d backend:\n",
+                Syntax("import vedo", lexer="python"),
+                Syntax("vedo.settings.default_backend = 'k3d'", lexer="python"),
             )
             return None

--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -46,7 +46,9 @@ class not_on_jupyter:  # pragma: no cover
                 f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook.",
                 f"[{orange_dark}]To use brainrender in a Jupyter notebook, set the vedo backend to 'k3d' before creating your scene:\n",
                 Syntax("import vedo", lexer="python"),
-                Syntax("vedo.settings.default_backend = 'k3d'", lexer="python"),
+                Syntax(
+                    "vedo.settings.default_backend = 'k3d'", lexer="python"
+                ),
                 f"[{orange_dark}]Note: some features are not available in the k3d backend.",
                 f"[{orange_dark}]To use all features, run brainrender in a standard Python script or interactive terminal instead.",
             )

--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -43,12 +43,11 @@ class not_on_jupyter:  # pragma: no cover
             return self.func(obj, *args, **kwargs)
         else:
             print(
-                f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook",
-                f"[{orange_dark}]To use brainrender outside of a Jupyter notebook, set the vedo backend before creating your scene:\n",
-                Syntax("import vedo", lexer="python"),
-                Syntax("vedo.settings.default_backend = 'vtk'", lexer="python"),
-                f"[{orange_dark}]Or to embed the scene inside the notebook, use the k3d backend:\n",
+                f"[{orange_dark}]Cannot run function [bold {salmon}]{self.func.__name__}[/ bold {salmon}] in a jupyter notebook.",
+                f"[{orange_dark}]To use brainrender in a Jupyter notebook, set the vedo backend to 'k3d' before creating your scene:\n",
                 Syntax("import vedo", lexer="python"),
                 Syntax("vedo.settings.default_backend = 'k3d'", lexer="python"),
+                f"[{orange_dark}]Note: some features are not available in the k3d backend.",
+                f"[{orange_dark}]To use all features, run brainrender in a standard Python script or interactive terminal instead.",
             )
             return None

--- a/brainrender/_jupyter.py
+++ b/brainrender/_jupyter.py
@@ -49,7 +49,7 @@ class not_on_jupyter:  # pragma: no cover
                 Syntax(
                     "vedo.settings.default_backend = 'k3d'", lexer="python"
                 ),
-                f"[{orange_dark}]Note: some features are not available in the k3d backend.",
+                f"\n[{orange_dark}]Note: some features are not available in the k3d backend.",
                 f"[{orange_dark}]To use all features, run brainrender in a standard Python script or interactive terminal instead.",
             )
             return None


### PR DESCRIPTION
## What does this PR do?
Fixes the misleading error message in `brainrender/_jupyter.py` that 
referenced `vedo.embedWindow`, which has been removed from the vedo library.

## Why is this needed?
Closes #413

## Changes
- Removed all references to the non-existent `embedWindow` API
- Updated the error message in the `not_on_jupyter` decorator to direct 
  users to set `vedo.settings.default_backend = 'k3d'` for notebook use
- Added a note that some features are unavailable in k3d, and recommends 
  running in a standard Python script or terminal for full functionality

## How was this tested?
- Verified valid vedo backend values directly from vedo 2026.6.1 source code
- `"k3d"` confirmed as the correct notebook backend in vedo settings

## Is this a breaking change?
No

## Does this require a documentation update?
No