### PR TITLE
fix: resolve video save path without os.chdir (fixes #378)

### DIFF
--- a/brainrender/_video.py
+++ b/brainrender/_video.py
@@ -30,7 +30,7 @@ class Video(VtkVideo):
         if self.size:
             fmt += f" -s {self.size}"
 
-        command = f"ffmpeg -hide_banner -loglevel panic -y -r {fps} -start_number 0 -i {fld} {fmt} {name}"
+        command = f'ffmpeg -hide_banner -loglevel panic -y -r {fps} -start_number 0 -i "{fld}" {fmt} "{name}"'
         out = os.system(command)
         self.tmp_dir.cleanup()
         return out, command

--- a/brainrender/video.py
+++ b/brainrender/video.py
@@ -106,13 +106,15 @@ class VideoMaker:
         uncompressed video
         """
 
-        command = f"ffmpeg -hide_banner -loglevel panic -i {temp_name}.mp4 -vcodec libx264 -crf 28 {self.save_name}.mp4 -y"
+        out_name = str(self.save_fld.resolve() / f"{self.save_name}.mp4")
+        command = f'ffmpeg -hide_banner -loglevel panic -i "{temp_name}.mp4" -vcodec libx264 -crf 28 "{out_name}" -y'
         os.system(command)
         Path(temp_name + ".mp4").unlink()
 
-        print(
-            f"[{amber}]Saved compressed video at: [{orange} bold]{self.save_fld}/{self.save_name}.{self.video_format}"
+        spath = str(
+            self.save_fld.resolve() / f"{self.save_name}.{self.video_format}"
         )
+        print(f"[{amber}]Saved compressed video at: [{orange} bold]{spath}")
 
     @not_on_jupyter
     def make_video(
@@ -154,14 +156,11 @@ class VideoMaker:
                 "focal_point"
             ] = self.scene.root._mesh.center_of_mass()
 
-        # cd to folder where the video will be saved
-        curdir = os.getcwd()
-        os.chdir(self.save_fld)
         print(f"[{amber}]Saving video in [{orange}]{self.save_fld}")
 
         # Create video
         video = Video(
-            name=self.save_name,
+            name=str(self.save_fld.resolve() / self.save_name),
             duration=duration,
             fps=fps,
             fmt=self.video_format,
@@ -174,7 +173,9 @@ class VideoMaker:
 
         # Stitch frames into uncompressed video
         out, command = video.close()
-        spath = f"{self.save_fld}/{self.save_name}.{self.video_format}"
+        spath = str(
+            self.save_fld.resolve() / f"{self.save_name}.{self.video_format}"
+        )
         if out:
             print(
                 f"[{orange} bold]ffmpeg returned an error while trying to save video with command:\n    [{salmon}]{command}"
@@ -184,7 +185,6 @@ class VideoMaker:
 
         # finish up
         br.settings.OFFSCREEN = _off
-        os.chdir(curdir)
         return spath
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from brainrender.scene import Scene
 from brainrender.video import Animation, VideoMaker
@@ -12,7 +13,7 @@ def test_video():
     vm = VideoMaker(s, "tests", "test")
     savepath = vm.make_video(duration=1, fps=15, azimuth=3)
 
-    assert savepath == "tests/test.mp4"
+    assert savepath == str(Path("tests").resolve() / "test.mp4")
     path = Path(savepath)
     assert path.exists()
     path.unlink()
@@ -30,7 +31,7 @@ def test_video_custom():
 
     savepath = vm.make_video(duration=1, fps=15, azimuth=3)
 
-    assert savepath == "tests/test.mp4"
+    assert savepath == str(Path("tests").resolve() / "test.mp4")
     path = Path(savepath)
     assert path.exists()
     path.unlink()
@@ -52,7 +53,38 @@ def test_animation():
     anim.add_keyframe(30, camera="frontal", zoom=2)  # too many
 
     savepath = anim.make_video(duration=3, fps=10)
-    assert savepath == "tests/test.mp4"
+    assert savepath == str(Path("tests").resolve() / "test.mp4")
     path = Path(savepath)
     assert path.exists()
     path.unlink()
+
+
+def test_compress(tmp_path):
+    """Test that compress() builds correct absolute paths without os.chdir."""
+    s = Scene(title="BR")
+    vm = VideoMaker(s, tmp_path, "myvideo")
+
+    # Create a fake uncompressed mp4 so Path.unlink() has something to remove
+    fake_mp4 = tmp_path / "temp_video.mp4"
+    fake_mp4.touch()
+
+    with (
+        patch("os.system") as mock_system,
+        patch.object(vm.scene.plotter, "close", return_value=None),
+    ):
+        mock_system.return_value = 0
+        vm.compress(str(tmp_path / "temp_video"))
+
+    # os.system was called once with absolute paths
+    assert mock_system.call_count == 1
+    cmd = mock_system.call_args[0][0]
+
+    expected_input = str((tmp_path / "temp_video.mp4").resolve())
+    expected_output = str((tmp_path / "myvideo.mp4").resolve())
+
+    assert expected_input in cmd, f"Input path missing from ffmpeg cmd: {cmd}"
+    assert (
+        expected_output in cmd
+    ), f"Output path missing from ffmpeg cmd: {cmd}"
+    # No bare filenames — must be absolute paths
+    assert "myvideo.mp4" not in cmd.replace(expected_output, "")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,21 +5,20 @@ from brainrender.scene import Scene
 from brainrender.video import Animation, VideoMaker
 
 
-def test_video():
+def test_video(tmp_path):
     s = Scene(title="BR")
 
     s.add_brain_region("TH")
 
-    vm = VideoMaker(s, "tests", "test")
+    vm = VideoMaker(s, tmp_path, "test")
     savepath = vm.make_video(duration=1, fps=15, azimuth=3)
 
-    assert savepath == str(Path("tests").resolve() / "test.mp4")
+    assert savepath == str((tmp_path / "test.mp4").resolve())
     path = Path(savepath)
     assert path.exists()
-    path.unlink()
 
 
-def test_video_custom():
+def test_video_custom(tmp_path):
     def custom(scene, *args, **kwargs):
         return
 
@@ -27,24 +26,23 @@ def test_video_custom():
 
     s.add_brain_region("TH")
 
-    vm = VideoMaker(s, "tests", "test", make_frame_func=custom)
+    vm = VideoMaker(s, tmp_path, "test", make_frame_func=custom)
 
     savepath = vm.make_video(duration=1, fps=15, azimuth=3)
 
-    assert savepath == str(Path("tests").resolve() / "test.mp4")
+    assert savepath == str((tmp_path / "test.mp4").resolve())
     path = Path(savepath)
     assert path.exists()
-    path.unlink()
 
 
-def test_animation():
+def test_animation(tmp_path):
     # Create a brainrender scene
     scene = Scene(title="brain regions", inset=False)
 
     # Add brain regions
     scene.add_brain_region("TH")
 
-    anim = Animation(scene, "tests", "test")
+    anim = Animation(scene, tmp_path, "test")
     anim.add_keyframe(0, camera="top", zoom=1.3)
     anim.add_keyframe(1, camera="sagittal", zoom=2.1)
     anim.add_keyframe(2, camera="frontal", zoom=3)
@@ -53,10 +51,9 @@ def test_animation():
     anim.add_keyframe(30, camera="frontal", zoom=2)  # too many
 
     savepath = anim.make_video(duration=3, fps=10)
-    assert savepath == str(Path("tests").resolve() / "test.mp4")
+    assert savepath == str((tmp_path / "test.mp4").resolve())
     path = Path(savepath)
     assert path.exists()
-    path.unlink()
 
 
 def test_compress(tmp_path):


### PR DESCRIPTION
## Summary
Fixes #378 by removing `os.chdir()` from `VideoMaker.make_video()` and switching to explicit absolute paths throughout the video pipeline.

## Root Cause
`make_video()` called `os.chdir(self.save_fld)` so ffmpeg could locate the output file using only a bare filename. The CWD was restored at the end — but only on the happy path. Any exception during rendering left the process CWD permanently mutated, causing subsequent path operations in the caller's script to silently resolve to the wrong location. This explains the intermittent nature of the bug.

`_video.py` compounded this by passing only a filename to ffmpeg, making output placement entirely dependent on global CWD state.

## Changes
- `brainrender/video.py`: removed `curdir = os.getcwd()` and both `os.chdir()` calls; `Video()` now receives a fully-resolved absolute path via `self.save_fld.resolve()`; `compress()` updated to match
- `brainrender/_video.py`: ffmpeg input dir and output file both quoted to handle paths with spaces
- `tests/test_video.py`: assertions updated to validate resolved absolute paths
- tests/test_video.py::test_compress PASSED
## Verification
```
tests/test_video.py::test_video PASSED
tests/test_video.py::test_video_custom PASSED
tests/test_video.py::test_animation PASSED
```