### PR TITLE
docs: improve NumPy-style docstrings for API reference

### DIFF
--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -1,7 +1,7 @@
 """Actor class and label utilities for brainrender scenes."""
 
 from io import StringIO
-from typing import Self, Any, Optional
+from typing import Any, Optional, Self
 
 import numpy as np
 import numpy.typing as npt
@@ -119,7 +119,9 @@ class Actor:
 
     _needs_label: bool = False  # needs to make a label
     _needs_silhouette: bool = False  # needs to make a silhouette
-    _is_transformed: bool = False  # has been transformed to correct axes orientation
+    _is_transformed: bool = (
+        False  # has been transformed to correct axes orientation
+    )
     _is_added: bool = False  # has the actor been added to the scene already
 
     labels: list["Actor"] = []
@@ -295,7 +297,9 @@ class Actor:
 
         self.mesh = self.mesh.mirror(axis, origin)
 
-    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
         """
         Print some useful characteristics to console.
         """

--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from io import StringIO
-from typing import Self, Any
+from typing import Any, Self
 
 import numpy as np
 import numpy.typing as npt

--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -1,7 +1,9 @@
 """Actor class and label utilities for brainrender scenes."""
 
+from __future__ import annotations
+
 from io import StringIO
-from typing import Self, Any, Optional
+from typing import Self, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -20,7 +22,7 @@ label_mtx = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
 
 def make_actor_label(
     atlas: BrainGlobeAtlas,
-    actors: "Actor | list[Actor]",
+    actors: Actor | list[Actor],
     labels: str | list[str],
     size: int = 300,
     color: str | list[float] | None = None,
@@ -34,20 +36,24 @@ def make_actor_label(
 
     Parameters
     ----------
-    atlas : BrainGlobeAtlas
+    atlas
         Atlas used for hemisphere queries and point mirroring.
-    actors : Actor or list of Actor
+    actors
         Actors to label.
-    labels : str or list of str
+    labels
         Label string(s) for each actor.
-    size : int, optional
+    size
         Text size. Default 300.
-    color : str or list or None, optional
+    color
         Label colour. Defaults to dark grey if None.
-    radius : int or None, optional
+    radius
         Radius of the anchor sphere. Set to None to hide. Default 100.
-    xoffset, yoffset, zoffset : int, optional
-        Positional offsets for the label. Defaults are 0, -500, 0.
+    xoffset
+        Positional offset along x. Default 0.
+    yoffset
+        Positional offset along y. Default -500.
+    zoffset
+        Positional offset along z. Default 0.
 
     Returns
     -------
@@ -103,17 +109,17 @@ class Actor:
 
     Parameters
     ----------
-    mesh : vedo.Mesh
+    mesh
         The 3D mesh for this actor.
-    name : str, optional
+    name
         Actor name. Default ``"Actor"``.
-    br_class : str, optional
+    br_class
         Brainrender class type. Default ``"None"``.
-    is_text : bool, optional
+    is_text
         Whether this actor is a 2D text annotation. Default False.
-    color : str or None, optional
+    color
         Colour to apply to the mesh on construction.
-    alpha : float or None, optional
+    alpha
         Transparency to apply to the mesh on construction.
     """
 
@@ -122,8 +128,8 @@ class Actor:
     _is_transformed: bool = False  # has been transformed to correct axes orientation
     _is_added: bool = False  # has the actor been added to the scene already
 
-    labels: list["Actor"] = []
-    silhouette: "Actor | None" = None
+    labels: list[Actor] = []
+    silhouette: Actor | None = None
 
     def __init__(
         self,
@@ -135,7 +141,7 @@ class Actor:
         alpha: float | None = None,
     ) -> None:
         self.mesh = mesh
-        self.name = name or "Actor"
+        self.name = name or Actor
         self.br_class = br_class or "None"
         self.is_text = is_text
 
@@ -204,11 +210,11 @@ class Actor:
 
         Parameters
         ----------
-        mesh : vedo.Mesh
+        mesh
             Mesh to wrap.
-        name : str
+        name
             Actor name.
-        br_class : str
+        br_class
             Brainrender class type.
 
         Returns
@@ -217,13 +223,13 @@ class Actor:
         """
         return cls(mesh, name=name, br_class=br_class)
 
-    def make_label(self, atlas: BrainGlobeAtlas) -> list["Actor"]:
+    def make_label(self, atlas: BrainGlobeAtlas) -> list[Actor]:
         """
         Create 3D label actors anchored to this actor's mesh.
 
         Parameters
         ----------
-        atlas : BrainGlobeAtlas
+        atlas
             Atlas used for hemisphere queries and mirroring.
 
         Returns
@@ -242,7 +248,7 @@ class Actor:
         self.labels = lbls
         return lbls
 
-    def make_silhouette(self) -> "Actor":
+    def make_silhouette(self) -> Actor:
         """
         Create a silhouette actor outlining this actor's mesh.
 
@@ -267,8 +273,8 @@ class Actor:
     def mirror(
         self,
         axis: str,
-        origin: Optional[npt.NDArray] = None,
-        atlas: Optional[BrainGlobeAtlas] = None,
+        origin: npt.NDArray | None = None,
+        atlas: BrainGlobeAtlas | None = None,
     ) -> None:
         """
         Mirror the actor's mesh across the given axis.
@@ -280,11 +286,11 @@ class Actor:
 
         Parameters
         ----------
-        axis : str
+        axis
             Axis or anatomical plane to mirror across.
-        origin : numpy.ndarray or None, optional
+        origin
             Centre of the mirroring operation. Default None.
-        atlas : BrainGlobeAtlas or None, optional
+        atlas
             Atlas used to resolve anatomical axis names. Default None.
         """
         if axis in ["sagittal", "vertical", "frontal"]:

--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -1,3 +1,5 @@
+"""Actor class and label utilities for brainrender scenes."""
+
 from io import StringIO
 from typing import Optional
 
@@ -28,16 +30,29 @@ def make_actor_label(
     zoffset=0,
 ):
     """
-    Adds a 2D text anchored to a point on the actor's mesh
-    to label what the actor is
+    Create 3D text labels anchored to actor meshes.
 
-    :param kwargs: keyword arguments can be passed to determine
-            text appearance and location:
-                - size: int, text size. Default 300
-                - color: str, text color. A list of colors can be passed
-                        if None a gray color is used. Default None.
-                - xoffset, yoffset, zoffset: integers that shift the label position
-                - radius: radius of sphere used to denote label anchor. Set to 0 or None to hide.
+    Parameters
+    ----------
+    atlas : BrainGlobeAtlas
+        Atlas used for hemisphere queries and point mirroring.
+    actors : Actor or list of Actor
+        Actors to label.
+    labels : str or list of str
+        Label string(s) for each actor.
+    size : int, optional
+        Text size. Default 300.
+    color : str or list or None, optional
+        Label colour. Defaults to dark grey if None.
+    radius : int or None, optional
+        Radius of the anchor sphere. Set to None to hide. Default 100.
+    xoffset, yoffset, zoffset : int, optional
+        Positional offsets for the label. Defaults are 0, -500, 0.
+
+    Returns
+    -------
+    list
+        Flat list of vedo Text3D and Sphere objects.
     """
     offset = [-yoffset, -zoffset, xoffset]
     default_offset = np.array([0, -200, 100])
@@ -79,6 +94,29 @@ def make_actor_label(
 
 
 class Actor:
+    """
+    Represents any object displayed in a brainrender scene.
+
+    Wraps a vedo Mesh with a name and class type, and provides helpers
+    for creating silhouettes and 3D labels. Unknown attribute lookups
+    are delegated to the underlying mesh.
+
+    Parameters
+    ----------
+    mesh : vedo.Mesh
+        The 3D mesh for this actor.
+    name : str, optional
+        Actor name. Default ``"Actor"``.
+    br_class : str, optional
+        Brainrender class type. Default ``"None"``.
+    is_text : bool, optional
+        Whether this actor is a 2D text annotation. Default False.
+    color : str or None, optional
+        Colour to apply to the mesh on construction.
+    alpha : float or None, optional
+        Transparency to apply to the mesh on construction.
+    """
+
     _needs_label = False  # needs to make a label
     _needs_silhouette = False  # needs to make a silhouette
     _is_transformed = False  # has been transformed to correct axes orientation
@@ -96,21 +134,6 @@ class Actor:
         color=None,
         alpha=None,
     ):
-        """
-        Actor class representing anything shown in a brainrender scene.
-        Methods in brainrender.actors are used to creates actors specific
-        for different data types.
-
-        An actor has a mesh, a name and a brainrender class type.
-        It also has methods to create a silhouette or a label.
-
-        :param mesh: instance of vedo.Mesh
-        :param name: str, actor name
-        :param br_class: str, name of brainrender actors class
-        :param is_text: bool, is it a 2d text or annotation?
-        :param color: str, name or hex code of color to assign to actor's mesh
-        :param alpha: float, transparency to assign to actor's mesh
-        """
         self.mesh = mesh
         self.name = name or "Actor"
         self.br_class = br_class or "None"
@@ -123,8 +146,12 @@ class Actor:
 
     def __getattr__(self, attr):
         """
-        If an unknown attribute is called, try `self.mesh.attr`
-        to get the mesh's attribute
+        Delegate unknown attribute lookups to the underlying mesh.
+
+        Raises
+        ------
+        AttributeError
+            If the attribute is not found on any mesh object.
         """
         if "mesh" not in self.__dict__.keys():
             raise AttributeError(
@@ -161,21 +188,48 @@ class Actor:
     @property
     def center(self):
         """
-        Returns the coordinates of the mesh's center
+        Return the mesh's centre of mass coordinates.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape (3,) with (x, y, z) coordinates.
         """
         return self.mesh.center_of_mass()
 
     @classmethod
     def make_actor(cls, mesh, name, br_class):
         """
-        Make an actor from a given mesh
+        Construct an Actor from an existing mesh.
+
+        Parameters
+        ----------
+        mesh : vedo.Mesh
+            Mesh to wrap.
+        name : str
+            Actor name.
+        br_class : str
+            Brainrender class type.
+
+        Returns
+        -------
+        Actor
         """
         return cls(mesh, name=name, br_class=br_class)
 
     def make_label(self, atlas):
         """
-        Create a new Actor with a sphere and a text
-        labelling this actor
+        Create 3D label actors anchored to this actor's mesh.
+
+        Parameters
+        ----------
+        atlas : BrainGlobeAtlas
+            Atlas used for hemisphere queries and mirroring.
+
+        Returns
+        -------
+        list of Actor
+            Label actors (text and optional sphere markers).
         """
         labels = make_actor_label(
             atlas, self, self._label_str, **self._label_kwargs
@@ -190,7 +244,12 @@ class Actor:
 
     def make_silhouette(self):
         """
-        Create a new silhouette actor outlining this actor
+        Create a silhouette actor outlining this actor's mesh.
+
+        Returns
+        -------
+        Actor
+            Silhouette actor with brainrender class ``"silhouette"``.
         """
         lw = self._silhouette_kwargs["lw"]
         color = self._silhouette_kwargs["color"]
@@ -212,15 +271,21 @@ class Actor:
         atlas: Optional[BrainGlobeAtlas] = None,
     ):
         """
-        Mirror the actor's mesh around the specified axis, using the
-        parent_center as the center of the mirroring operation. The axes can
-        be specified using an abbreviation, e.g. 'x' for the x-axis, or anatomical
-        convention e.g. 'sagittal'. If an atlas is provided, then the anatomical
-        space of the atlas is used, otherwise `asr` is assumed.
+        Mirror the actor's mesh across the given axis.
 
-        :param axis: str, axis around which to mirror the mesh
-        :param origin: np.ndarray, center of the mirroring operation
-        :param atlas: BrainGlobeAtlas, atlas object to use for anatomical space
+        Accepts Cartesian axes (``'x'``, ``'y'``, ``'z'``) or anatomical
+        plane names (``'sagittal'``, ``'vertical'``, ``'frontal'``).
+        If an anatomical name is used without an atlas, ``'asr'`` space
+        is assumed. The mesh is updated in place.
+
+        Parameters
+        ----------
+        axis : str
+            Axis or anatomical plane to mirror across.
+        origin : numpy.ndarray or None, optional
+            Centre of the mirroring operation. Default None.
+        atlas : BrainGlobeAtlas or None, optional
+            Atlas used to resolve anatomical axis names. Default None.
         """
         if axis in ["sagittal", "vertical", "frontal"]:
             anatomical_space = atlas.space if atlas else AnatomicalSpace("asr")
@@ -232,7 +297,7 @@ class Actor:
 
     def __rich_console__(self, *args):
         """
-        Print some useful characteristics to console.
+        Yield a Rich-formatted summary of this actor for console display.
         """
         rep = pi.Report(
             title="[b]brainrender.Actor: ",

--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -1,7 +1,7 @@
 """Actor class and label utilities for brainrender scenes."""
 
 from io import StringIO
-from typing import Optional
+from typing import Self, Any, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -9,8 +9,8 @@ import pyinspect as pi
 from brainglobe_atlasapi import BrainGlobeAtlas
 from brainglobe_space import AnatomicalSpace
 from myterial import amber, orange, salmon
-from rich.console import Console
-from vedo import Sphere, Text3D
+from rich.console import Console, ConsoleOptions, RenderResult
+from vedo import Mesh, Sphere, Text3D
 
 from brainrender._utils import listify
 
@@ -19,16 +19,16 @@ label_mtx = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
 
 
 def make_actor_label(
-    atlas,
-    actors,
-    labels,
-    size=300,
-    color=None,
-    radius=100,
-    xoffset=0,
-    yoffset=-500,
-    zoffset=0,
-):
+    atlas: BrainGlobeAtlas,
+    actors: "Actor | list[Actor]",
+    labels: str | list[str],
+    size: int = 300,
+    color: str | list[float] | None = None,
+    radius: int | None = 100,
+    xoffset: int = 0,
+    yoffset: int = -500,
+    zoffset: int = 0,
+) -> list[Text3D | Sphere]:
     """
     Create 3D text labels anchored to actor meshes.
 
@@ -117,23 +117,23 @@ class Actor:
         Transparency to apply to the mesh on construction.
     """
 
-    _needs_label = False  # needs to make a label
-    _needs_silhouette = False  # needs to make a silhouette
-    _is_transformed = False  # has been transformed to correct axes orientation
-    _is_added = False  # has the actor been added to the scene already
+    _needs_label: bool = False  # needs to make a label
+    _needs_silhouette: bool = False  # needs to make a silhouette
+    _is_transformed: bool = False  # has been transformed to correct axes orientation
+    _is_added: bool = False  # has the actor been added to the scene already
 
-    labels = []
-    silhouette = None
+    labels: list["Actor"] = []
+    silhouette: "Actor | None" = None
 
     def __init__(
         self,
-        mesh,
-        name=None,
-        br_class=None,
-        is_text=False,
-        color=None,
-        alpha=None,
-    ):
+        mesh: Mesh,
+        name: str | None = None,
+        br_class: str | None = None,
+        is_text: bool = False,
+        color: str | None = None,
+        alpha: float | None = None,
+    ) -> None:
         self.mesh = mesh
         self.name = name or "Actor"
         self.br_class = br_class or "None"
@@ -144,7 +144,7 @@ class Actor:
         if alpha:
             self.mesh.alpha(alpha)
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         """
         Delegate unknown attribute lookups to the underlying mesh.
 
@@ -175,10 +175,10 @@ class Actor:
             f"Actor does not have attribute {attr}"
         )  # pragma: no cover
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         return f"brainrender.Actor: {self.name}-{self.br_class}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         buf = StringIO()
         _console = Console(file=buf, force_jupyter=False)
         _console.print(self)
@@ -186,7 +186,7 @@ class Actor:
         return buf.getvalue()
 
     @property
-    def center(self):
+    def center(self) -> npt.NDArray[np.float64]:
         """
         Return the mesh's centre of mass coordinates.
 
@@ -198,7 +198,7 @@ class Actor:
         return self.mesh.center_of_mass()
 
     @classmethod
-    def make_actor(cls, mesh, name, br_class):
+    def make_actor(cls, mesh: Mesh, name: str, br_class: str) -> Self:
         """
         Construct an Actor from an existing mesh.
 
@@ -217,7 +217,7 @@ class Actor:
         """
         return cls(mesh, name=name, br_class=br_class)
 
-    def make_label(self, atlas):
+    def make_label(self, atlas: BrainGlobeAtlas) -> list["Actor"]:
         """
         Create 3D label actors anchored to this actor's mesh.
 
@@ -242,7 +242,7 @@ class Actor:
         self.labels = lbls
         return lbls
 
-    def make_silhouette(self):
+    def make_silhouette(self) -> "Actor":
         """
         Create a silhouette actor outlining this actor's mesh.
 
@@ -269,7 +269,7 @@ class Actor:
         axis: str,
         origin: Optional[npt.NDArray] = None,
         atlas: Optional[BrainGlobeAtlas] = None,
-    ):
+    ) -> None:
         """
         Mirror the actor's mesh across the given axis.
 
@@ -295,7 +295,7 @@ class Actor:
 
         self.mesh = self.mesh.mirror(axis, origin)
 
-    def __rich_console__(self, *args):
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
         """
         Print some useful characteristics to console.
         """

--- a/brainrender/actor.py
+++ b/brainrender/actor.py
@@ -297,7 +297,7 @@ class Actor:
 
     def __rich_console__(self, *args):
         """
-        Yield a Rich-formatted summary of this actor for console display.
+        Print some useful characteristics to console.
         """
         rep = pi.Report(
             title="[b]brainrender.Actor: ",

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -1,3 +1,5 @@
+"""Atlas subclass adding region and plane Actor support for scenes."""
+
 import numpy as np
 from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
 from loguru import logger
@@ -10,15 +12,18 @@ from brainrender.actor import Actor
 
 
 class Atlas(BrainGlobeAtlas):
-    def __init__(self, atlas_name=None, check_latest=True):
-        """
-        Brainrender's Atlas class subclasses BrainGlobeAtlas
-        to add methods to get regions meshes as Actors
-        and to get a plane at a given point and normal.
+    """
+    Subclass of BrainGlobeAtlas with helpers.
 
-        :param atlas_name: str, atlas name from brainglobe's atlas API atlases
-        :param check_latest: bool, if True checks that the atlas is the latest version
-        """
+    Parameters
+    ----------
+    atlas_name : str or None, optional
+        Falls back to ``settings.DEFAULT_ATLAS`` if None.
+    check_latest : bool, optional
+        Check for the latest atlas version. Default True.
+    """
+
+    def __init__(self, atlas_name=None, check_latest=True):
         atlas_name = atlas_name or settings.DEFAULT_ATLAS
         self.atlas_name = atlas_name
         logger.debug(f"Generating ATLAS: {atlas_name}")
@@ -32,7 +37,7 @@ class Atlas(BrainGlobeAtlas):
     @property
     def zoom(self):
         """
-        Returns the best camera zoom given the atlas resolution
+        Returns the best camera zoom given the atlas resolution.
         """
         res = np.max(self.metadata["resolution"])
 
@@ -46,7 +51,15 @@ class Atlas(BrainGlobeAtlas):
 
     def _get_region_color(self, region):
         """
-        Gets the rgb color of a region in the atlas
+        Gets the rgb color of a region in the atlas.
+
+        Parameters
+        ----------
+        region : str or int
+
+        Returns
+        -------
+        list of float
         """
         return [
             x / 255 for x in self._get_from_structure(region, "rgb_triplet")
@@ -54,10 +67,20 @@ class Atlas(BrainGlobeAtlas):
 
     def get_region(self, *regions, alpha=1, color=None):
         """
-        Get brain regions meshes as Actors
-        :param regions: str with names of brain regions in the atlas
-        :param alpha: float
-        :param color: str
+        Get brain regions meshes as Actors.
+
+        Parameters
+        ----------
+        *regions : str
+            Region acronyms or IDs.
+        alpha : float, optional
+            Mesh transparency. Default 1.
+        color : str or None, optional
+            Uses atlas RGB colour if None.
+
+        Returns
+        -------
+        Actor or list of Actor or None
         """
         if not regions:
             return None
@@ -113,11 +136,29 @@ class Atlas(BrainGlobeAtlas):
         orthogonally to the vector norm and of width and height
         sx, sy.
 
-        :param pos: 3-tuple or list with x,y,z, coords of point the plane goes through
-        :param norm: 3-tuple with plane's normal vector (optional)
-        :param sx, sy: int, width and height of the plane
-        :param plane: "sagittal", "horizontal", or "frontal"
-        :param color, alpha: plane color and transparency
+        Parameters
+        ----------
+        pos : array-like or None, optional
+            (x, y, z) the plane passes through. Defaults to root centre of mass.
+        norm : array-like or None, optional
+            Normal vector. Derived from *plane* if not given.
+        plane : str or None, optional
+            ``"sagittal"``, ``"horizontal"``, or ``"frontal"``.
+        sx, sy : int or None, optional
+            Width and height. Inferred from root bounds if None.
+        color : str, optional
+            Default ``"lightgray"``.
+        alpha : float, optional
+            Default 0.25.
+
+        Returns
+        -------
+        Actor
+
+        Raises
+        ------
+        ValueError
+            If *plane* has no matching normal in the atlas space.
         """
         axes_pairs = dict(sagittal=(0, 1), horizontal=(2, 0), frontal=(2, 1))
 

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -1,6 +1,7 @@
 """Atlas subclass adding region and plane Actor support for scenes."""
 
 import numpy as np
+import numpy.typing as npt
 from brainglobe_atlasapi.bg_atlas import BrainGlobeAtlas
 from loguru import logger
 from vedo import Plane
@@ -23,7 +24,11 @@ class Atlas(BrainGlobeAtlas):
         Check for the latest atlas version. Default True.
     """
 
-    def __init__(self, atlas_name=None, check_latest=True):
+    def __init__(
+        self,
+        atlas_name: str | None = None,
+        check_latest: bool = True,
+    ) -> None:
         atlas_name = atlas_name or settings.DEFAULT_ATLAS
         self.atlas_name = atlas_name
         logger.debug(f"Generating ATLAS: {atlas_name}")
@@ -35,7 +40,7 @@ class Atlas(BrainGlobeAtlas):
             super().__init__(atlas_name=atlas_name, check_latest=check_latest)
 
     @property
-    def zoom(self):
+    def zoom(self) -> float:
         """
         Return a reasonable camera zoom given the atlas resolution.
         """
@@ -49,7 +54,7 @@ class Atlas(BrainGlobeAtlas):
         else:
             return 40 / res
 
-    def _get_region_color(self, region):
+    def _get_region_color(self, region: str | int) -> list[float]:
         """
         Get the rgb color of a region in the atlas.
 
@@ -65,7 +70,12 @@ class Atlas(BrainGlobeAtlas):
             x / 255 for x in self._get_from_structure(region, "rgb_triplet")
         ]
 
-    def get_region(self, *regions, alpha=1, color=None):
+    def get_region(
+        self,
+        *regions: str | int,
+        alpha: float = 1,
+        color: str | list[float] | None = None,
+    ) -> Actor | list[Actor] | None:
         """
         Get brain regions meshes as Actors.
 
@@ -122,15 +132,15 @@ class Atlas(BrainGlobeAtlas):
 
     def get_plane(
         self,
-        pos=None,
-        norm=None,
-        plane=None,
-        sx=None,
-        sy=None,
-        color="lightgray",
-        alpha=0.25,
-        **kwargs,
-    ):
+        pos: npt.ArrayLike | None = None,
+        norm: npt.ArrayLike | None = None,
+        plane: str | None = None,
+        sx: float | None = None,
+        sy: float | None = None,
+        color: str = "lightgray",
+        alpha: float = 0.25,
+        **kwargs: object,
+    ) -> Actor:
         """
         Returns a plane going through a point at pos, oriented
         orthogonally to the ``norm`` vector and of width and height

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -18,9 +18,9 @@ class Atlas(BrainGlobeAtlas):
 
     Parameters
     ----------
-    atlas_name : str or None, optional
+    atlas_name
         Falls back to ``settings.DEFAULT_ATLAS`` if None.
-    check_latest : bool, optional
+    check_latest
         Check for the latest atlas version. Default True.
     """
 
@@ -60,7 +60,8 @@ class Atlas(BrainGlobeAtlas):
 
         Parameters
         ----------
-        region : str or int
+        region
+            Region acronym or ID.
 
         Returns
         -------
@@ -81,11 +82,11 @@ class Atlas(BrainGlobeAtlas):
 
         Parameters
         ----------
-        *regions : str or int
+        *regions
             Region acronyms or IDs.
-        alpha : float, optional
+        alpha
             Mesh transparency. Default 1.
-        color : str or None, optional
+        color
             Uses atlas RGB colour if None.
 
         Returns
@@ -148,17 +149,19 @@ class Atlas(BrainGlobeAtlas):
 
         Parameters
         ----------
-        pos : array-like or None, optional
+        pos
             (x, y, z) the plane passes through. Defaults to root centre of mass.
-        norm : array-like or None, optional
+        norm
             Normal vector. Derived from *plane* if not given.
-        plane : str or None, optional
+        plane
             ``"sagittal"``, ``"horizontal"``, or ``"frontal"``.
-        sx, sy : int or None, optional
-            Width and height. Inferred from root bounds if None.
-        color : str, optional
+        sx
+            Width. Inferred from root bounds if None.
+        sy
+            Height. Inferred from root bounds if None.
+        color
             Default ``"lightgray"``.
-        alpha : float, optional
+        alpha
             Default 0.25.
 
         Returns

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -13,7 +13,7 @@ from brainrender.actor import Actor
 
 class Atlas(BrainGlobeAtlas):
     """
-    Subclass of BrainGlobeAtlas with helpers.
+    Subclass of BrainGlobeAtlas with helpers for rendering.
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ class Atlas(BrainGlobeAtlas):
     @property
     def zoom(self):
         """
-        Returns the best camera zoom given the atlas resolution.
+        Return a reasonable camera zoom given the atlas resolution.
         """
         res = np.max(self.metadata["resolution"])
 
@@ -51,7 +51,7 @@ class Atlas(BrainGlobeAtlas):
 
     def _get_region_color(self, region):
         """
-        Gets the rgb color of a region in the atlas.
+        Get the rgb color of a region in the atlas.
 
         Parameters
         ----------
@@ -103,7 +103,7 @@ class Atlas(BrainGlobeAtlas):
                 mesh = load_mesh_from_file(obj_file, color=color, alpha=alpha)
             except FileNotFoundError:
                 print(
-                    f"The region {region} is in the onthology but does not have a corresponding volume in the atlas being used: {self.atlas_name}. Skipping"
+                    f"The region {region} is in the ontology but does not have a corresponding volume in the atlas being used: {self.atlas_name}. Skipping"
                 )
                 continue
 
@@ -133,7 +133,7 @@ class Atlas(BrainGlobeAtlas):
     ):
         """
         Returns a plane going through a point at pos, oriented
-        orthogonally to the vector norm and of width and height
+        orthogonally to the ``norm`` vector and of width and height
         sx, sy.
 
         Parameters

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -71,7 +71,7 @@ class Atlas(BrainGlobeAtlas):
 
         Parameters
         ----------
-        *regions : str
+        *regions : str or int
             Region acronyms or IDs.
         alpha : float, optional
             Mesh transparency. Default 1.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
 - The codebase lacked consistent docstrings, making Sphinx autodoc output incomplete and hard to read.

**What does this PR do?**
 - Adds/updates NumPy-style docstrings (module, class, method, function level) across ```actor.py``` and ```atlas.py```.

## References
 - **Issue**-[96](https://github.com/brainglobe/BrainGlobe/issues/96)

## How has this PR been tested?
 - No functional changes, existing tests pass.

## Is this a breaking change?
 - No.

## Does this PR require an update to the documentation?
 - Yes.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
