### PR TITLE
Fetch atlas meshes by loading meshio and converting to vedo mesh

### DIFF
--- a/brainrender/_io.py
+++ b/brainrender/_io.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import requests
-from vedo import load
+from vedo import Mesh, load
 
 
 def connected_to_internet(url="http://www.google.com/", timeout=5):
@@ -83,5 +83,28 @@ def load_mesh_from_file(filepath, color=None, alpha=None):
 
     """
     actor = load(str(filepath))
+    actor.c(color).alpha(alpha)
+    return actor
+
+
+def convert_meshio_to_vedo(meshio_mesh, color=None, alpha=None):
+    """
+    Convert a meshio mesh to a vedo mesh.
+
+    Parameters
+    ----------
+    meshio_mesh : meshio.Mesh
+        The meshio mesh to convert.
+    color : str, optional
+        The color to apply to the mesh. Default is None.
+    alpha : float, optional
+        The transparency to apply to the mesh. Default is None.
+
+    Returns
+    -------
+    vedo.Mesh
+        The converted vedo mesh.
+    """
+    actor = Mesh([meshio_mesh.points, meshio_mesh.cells_dict["triangle"]])
     actor.c(color).alpha(alpha)
     return actor

--- a/brainrender/atlas.py
+++ b/brainrender/atlas.py
@@ -9,7 +9,7 @@ from loguru import logger
 from vedo import Plane
 
 from brainrender import settings
-from brainrender._io import load_mesh_from_file
+from brainrender._io import convert_meshio_to_vedo
 from brainrender._utils import return_list_smart
 from brainrender.actor import Actor
 
@@ -111,9 +111,11 @@ class Atlas(BrainGlobeAtlas):
                 continue
 
             # Get mesh
-            obj_file = str(self.meshfile_from_structure(region))
             try:
-                mesh = load_mesh_from_file(obj_file, color=color, alpha=alpha)
+                meshio_mesh = self.mesh_from_structure(region)
+                mesh = convert_meshio_to_vedo(
+                    meshio_mesh, color=color, alpha=alpha
+                )
             except FileNotFoundError:
                 print(
                     f"The region {region} is in the ontology but does not have a corresponding volume in the atlas being used: {self.atlas_name}. Skipping"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "h5py",
     "k3d",
     "loguru",
+    "meshio",
     "morphapi>=0.3.3",
     "msgpack",
     "myterial",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,41 @@
+import meshio
+import numpy as np
+import pytest
+from vedo import Mesh
+from vedo.colors import get_color
+
+from brainrender._io import convert_meshio_to_vedo
+
+points = np.array(
+    [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+)
+triangles = np.array([[0, 1, 2], [0, 1, 3], [1, 2, 3], [0, 2, 3]])
+
+
+@pytest.fixture
+def meshio_mesh():
+    return meshio.Mesh(points, [("triangle", triangles)])
+
+
+def test_convert_meshio_to_vedo(meshio_mesh):
+    actor = convert_meshio_to_vedo(meshio_mesh)
+
+    assert isinstance(actor, Mesh)
+    assert np.allclose(actor.vertices, points)
+    assert np.array_equal(np.array(actor.cells), triangles)
+
+
+def test_convert_meshio_to_vedo_color_and_alpha(meshio_mesh):
+    actor = convert_meshio_to_vedo(meshio_mesh, color="red", alpha=0.4)
+
+    assert np.allclose(actor.color(), get_color("red"))
+    assert actor.alpha() == pytest.approx(0.4)
+
+
+def test_convert_meshio_to_vedo_ignores_non_triangle_cells():
+    mesh = meshio.Mesh(
+        points, [("line", np.array([[0, 1]])), ("triangle", triangles)]
+    )
+    actor = convert_meshio_to_vedo(mesh)
+
+    assert actor.ncells == len(triangles)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Following the release of `brainglobe-atlasapi==3.0.0rc0` meshes are no longer stored on disk as .obj files. `brainrender` accesses these files directly to load meshes into `vedo`.

**What does this PR do?**
Alters the loading path for atlas meshes. `brainrender` now requests the mesh directly from `brainglobe-atlasapi` receiving a `meshio.Mesh`, this is converted into a `vedo.Mesh` and passed through as before.

## References
#460 

## How has this PR been tested?
All tests pass locally and local examples involving atlas meshes have been inspected in an environment with `brainglobe-atlasapi==3.0.0rc0` and `brainglobe-atlasapi==2.3.1`

## Is this a breaking change?
No, this change is backwards compatible with `brainglobe-atlasapi<3.0.0`

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
