### PR TITLE
docs: improve NumPy-style docstrings in actors modules

### DIFF
--- a/brainrender/actors/cylinder.py
+++ b/brainrender/actors/cylinder.py
@@ -1,3 +1,6 @@
+"""Cylinder actor for brainrender scenes."""
+
+import numpy.typing as npt
 from loguru import logger
 from vedo import Mesh, shapes
 
@@ -5,17 +8,30 @@ from brainrender.actor import Actor
 
 
 class Cylinder(Actor):
-    def __init__(self, pos, root, color="powderblue", alpha=1, radius=350):
-        """
-        Cylinder class creates a cylinder mesh between a given
-        point and the brain's surface.
+    """Actor representing a cylinder between a point and the brain's surface."""
 
-        :param pos: list, np.array of ap, dv, ml coordinates.
-            If an actor is passed, gets the center of mass instead
-        :param root: brain root Actor or mesh object
-        :param color: str, color
-        :param alpha: float
-        :param radius: float
+    def __init__(
+        self,
+        pos: npt.ArrayLike | Mesh | Actor,
+        root: Actor,
+        color: str = "powderblue",
+        alpha: float = 1,
+        radius: float = 350,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        pos
+            AP, DV, ML coordinates. If a Mesh or Actor is passed,
+            the centre of mass is used instead.
+        root
+            Brain root Actor or mesh.
+        color
+            Colour name. Default ``"powderblue"``.
+        alpha
+            Transparency. Default 1.
+        radius
+            Cylinder radius. Default 350.
         """
 
         # Get pos

--- a/brainrender/actors/line.py
+++ b/brainrender/actors/line.py
@@ -1,22 +1,35 @@
+"""Line actor for brainrender scenes."""
+
+import numpy.typing as npt
 from vedo import shapes
 
 from brainrender.actor import Actor
 
 
 class Line(Actor):
+    """Actor representing a line through a sequence of coordinates."""
+
     def __init__(
-        self, coordinates, color="black", alpha=1, linewidth=2, name=None
-    ):
+        self,
+        coordinates: npt.ArrayLike,
+        color: str | tuple = "black",
+        alpha: float = 1,
+        linewidth: float = 2,
+        name: str | None = None,
+    ) -> None:
         """
-        Creates an actor representing a single line.
-
-        :param coordinates: list, np.ndarray with shape (N, 3) of ap, dv, ml coordinates.
-        :param color: CSS named color str, hex code, or RGB tuple, e.g. "white", "#ffffff", or (255, 255, 255)
-        :param alpha: float in range 0.0 to 1.0
-        :param linewidth: float
-        :param name: str
+        Parameters
+        ----------
+        coordinates
+            Array of shape (N, 3) with AP, DV, ML coordinates.
+        color
+            CSS colour name, hex code, or RGB tuple. Default ``"black"``.
+        alpha
+            Transparency in range [0, 1]. Default 1.
+        linewidth
+            Line width. Default 2.
+        name
+            Actor name.
         """
-
-        # Create mesh and Actor
         mesh = shapes.Line(p0=coordinates, lw=linewidth, c=color, alpha=alpha)
         Actor.__init__(self, mesh, name=name, br_class="Line")

--- a/brainrender/actors/neurons.py
+++ b/brainrender/actors/neurons.py
@@ -1,3 +1,5 @@
+"""Neuron morphology actors for brainrender scenes."""
+
 from pathlib import Path
 
 from loguru import logger
@@ -9,16 +11,35 @@ from brainrender.actor import Actor
 
 
 def make_neurons(
-    *neurons, alpha=1, color=None, neurite_radius=8, soma_radius=15, name=None
-):
+    *neurons: str | Path | Mesh | Actor | MorphoNeuron,
+    alpha: float = 1,
+    color: str | None = None,
+    neurite_radius: float = 8,
+    soma_radius: float = 15,
+    name: str | None = None,
+) -> list["Neuron"]:
     """
-    Returns a list of Neurons given a variable number of inputs
-    :param neurons: any accepted data input for Neuron
-    :param alpha: float
-    :param color: str
-    :param neurite_radius: float, radius of axon/dendrites
-    :param soma_radius: float, radius of soma
-    :param name: str, actor name
+    Create Neuron actors from one or more inputs.
+
+    Parameters
+    ----------
+    *neurons
+        Any accepted input for Neuron.
+    alpha
+        Transparency. Default 1.
+    color
+        Colour name. Default ``"blackboard"``.
+    neurite_radius
+        Radius of axon/dendrites. Default 8.
+    soma_radius
+        Radius of soma. Default 15.
+    name
+        Actor name.
+
+    Returns
+    -------
+    list of Neuron
+        A list of Neuron actors, one for each input.
     """
     return [
         Neuron(
@@ -34,26 +55,42 @@ def make_neurons(
 
 
 class Neuron(Actor):
+    """Actor representing a single neuron's morphology."""
+
     def __init__(
         self,
-        neuron,
-        color=None,
-        alpha=1,
-        neurite_radius=8,
-        soma_radius=15,
-        invert_dims=True,
-        name=None,
-    ):
+        neuron: str | Path | Mesh | Actor | MorphoNeuron,
+        color: str | None = None,
+        alpha: float = 1,
+        neurite_radius: float = 8,
+        soma_radius: float = 15,
+        invert_dims: bool = True,
+        name: str | None = None,
+    ) -> None:
         """
-        Creates an Actor representing a single neuron's morphology
-        :param neuron: path to .swc file, Mesh, Actor or Neuron from morphapi.morphology
-        :param alpha: float
-        :param color: str,
-        :param neuron_radius: float, radius of axon/dendrites
-        :param soma_radius: float, radius of soma
-        :param invert_dims: bool, exchange the first and last dimension coordinates
-        when loading from a .swc file. e.g going from (x, y, z) to (z, y, x).
-        :param name: str, actor name
+        Parameters
+        ----------
+        neuron
+            Path to a ``.swc`` file, a Mesh, an Actor, or a
+            morphapi Neuron instance.
+        color
+            Colour name. Default ``"blackboard"``.
+        alpha
+            Transparency. Default 1.
+        neurite_radius
+            Radius of axon/dendrites. Default 8.
+        soma_radius
+            Radius of soma. Default 15.
+        invert_dims
+            If True, swap the first and last coordinate dimensions when
+            loading from a ``.swc`` file (e.g. ``(x, y, z)`` → ``(z, y, x)``).
+        name
+            Actor name.
+
+        Raises
+        ------
+        ValueError
+            If ``neuron`` is not a recognised input type.
         """
         logger.debug("Creating a Neuron actor")
         if color is None:
@@ -79,7 +116,20 @@ class Neuron(Actor):
         Actor.__init__(self, mesh, name=self.name, br_class="Neuron")
         self.mesh.c(color).alpha(alpha)
 
-    def _from_morphapi_neuron(self, neuron: MorphoNeuron):
+    def _from_morphapi_neuron(self, neuron: MorphoNeuron) -> Mesh:
+        """
+        Create a mesh from a morphapi Neuron instance.
+
+        Parameters
+        ----------
+        neuron
+            morphapi Neuron instance.
+
+        Returns
+        -------
+        vedo.Mesh
+            A mesh created from the morphapi Neuron instance.
+        """
         # Temporarily set cache to false as meshes were being corrupted
         # on second load
         mesh = neuron.create_mesh(
@@ -89,7 +139,32 @@ class Neuron(Actor):
         )[1]
         return mesh
 
-    def _from_file(self, neuron: (str, Path), invert_dims):
+    def _from_file(
+        self,
+        neuron: str | Path,
+        invert_dims: bool,
+    ) -> Mesh:
+        """
+        Load neuron morphology from a ``.swc`` file.
+
+        Parameters
+        ----------
+        neuron
+            Path to the ``.swc`` file.
+        invert_dims
+            If True, swap the first and last coordinate dimensions.
+
+        Returns
+        -------
+        vedo.Mesh
+
+        Raises
+        ------
+        FileExistsError
+            If the file does not exist.
+        NotImplementedError
+            If the file is not a ``.swc`` file.
+        """
         path = Path(neuron)
         if not path.exists():
             raise FileExistsError(f"Neuron file doesn't exist: {path}")

--- a/brainrender/actors/points.py
+++ b/brainrender/actors/points.py
@@ -7,8 +7,8 @@ import numpy as np
 import numpy.typing as npt
 from loguru import logger
 from pyinspect.utils import _class_name
-from vedo import Points as vPoints
 from vedo import Mesh, Sphere, Spheres
+from vedo import Points as vPoints
 
 from brainrender.actor import Actor
 

--- a/brainrender/actors/points.py
+++ b/brainrender/actors/points.py
@@ -1,26 +1,45 @@
+"""Point and point-cloud actors for brainrender scenes."""
+
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from loguru import logger
 from pyinspect.utils import _class_name
 from vedo import Points as vPoints
-from vedo import Sphere, Spheres
+from vedo import Mesh, Sphere, Spheres
 
 from brainrender.actor import Actor
 
 
 class Point(Actor):
+    """Actor representing a single point as a sphere."""
+
     def __init__(
-        self, pos, radius=100, color="blackboard", alpha=1, res=25, name=None
-    ):
+        self,
+        pos: npt.ArrayLike,
+        radius: float = 100,
+        color: str = "blackboard",
+        alpha: float = 1,
+        res: int = 25,
+        name: str | None = None,
+    ) -> None:
         """
-        Creates an actor representing a single point
-        :param pos: list or np.ndarray with coordinates
-        :param radius: float
-        :param color: str,
-        :param alpha: float
-        :param res: int, resolution of mesh
-        :param name: str, actor name
+        Parameters
+        ----------
+        pos
+            Coordinates of the point.
+        radius
+            Sphere radius. Default 100.
+        color
+            Colour name. Default ``"blackboard"``.
+        alpha
+            Transparency. Default 1.
+        res
+            Mesh resolution. Default 25.
+        name
+            Actor name. Default ``"Point"``.
         """
         logger.debug(f"Creating a point actor at: {pos}")
         mesh = Sphere(pos=pos, r=radius, c=color, alpha=alpha, res=res)
@@ -29,17 +48,28 @@ class Point(Actor):
 
 
 class PointsBase:
-    def __init__(
-        self,
-    ):
-        """
-        Base class with functionality to load from file.
-        """
+    """Base class with shared file-loading functionality for point actors."""
+
+    def __init__(self) -> None:
         return
 
-    def _from_numpy(self, data):
+    def _from_numpy(self, data: npt.NDArray) -> Mesh:
         """
-        Creates the mesh
+        Create a Spheres mesh from a numpy array.
+
+        Parameters
+        ----------
+        data
+            Nx3 array of point coordinates.
+
+        Returns
+        -------
+        vedo.Mesh
+
+        Raises
+        ------
+        ValueError
+            If the number of colours does not match the number of points.
         """
         N = len(data)
         if not isinstance(self.colors, str):
@@ -54,10 +84,34 @@ class PointsBase:
         )
         return mesh
 
-    def _from_file(self, data, colors="salmon", alpha=1):
+    def _from_file(
+        self,
+        data: str | Path,
+        colors: str = "salmon",
+        alpha: float = 1,
+    ) -> Mesh:
         """
-        Loads points coordinates from a numpy file
-        before creating the mesh.
+        Load point coordinates from a ``.npy`` file and create the mesh.
+
+        Parameters
+        ----------
+        data
+            Path to the ``.npy`` file.
+        colors
+            Colour name. Default ``"salmon"``.
+        alpha
+            Transparency. Default 1.
+
+        Returns
+        -------
+        vedo.Mesh
+
+        Raises
+        ------
+        FileExistsError
+            If the file does not exist.
+        NotImplementedError
+            If the file format is not ``.npy``.
         """
         path = Path(data)
         if not path.exists():
@@ -76,19 +130,39 @@ class PointsBase:
 
 
 class Points(PointsBase, Actor):
-    def __init__(
-        self, data, name=None, colors="salmon", alpha=1, radius=20, res=8
-    ):
-        """
-        Creates an actor representing multiple points (more efficient than
-        creating many Point instances).
+    """
+    Actor representing multiple points as spheres.
+    """
 
-        :param data: np.ndarray, Nx3 array or path to .npy file with coords data
-        :param radius: float
-        :param color: str, or list of str with color names or hex codes
-        :param alpha: float
-        :param name: str, actor name
-        :param res: int. Resolution of sphere actors
+    def __init__(
+        self,
+        data: npt.NDArray | str | Path,
+        name: str | None = None,
+        colors: str | list[str] = "salmon",
+        alpha: float = 1,
+        radius: float = 20,
+        res: int = 8,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        data
+            Nx3 array of coordinates, or path to a ``.npy`` file.
+        name
+            Actor name.
+        colors
+            Colour name or list of colour names/hex codes.
+        alpha
+            Transparency. Default 1.
+        radius
+            Sphere radius. Default 20.
+        res
+            Sphere mesh resolution. Default 8.
+
+        Raises
+        ------
+        TypeError
+            If ``data`` is not a numpy array or file path.
         """
         PointsBase.__init__(self)
         logger.debug("Creating a Points actor")
@@ -112,31 +186,32 @@ class Points(PointsBase, Actor):
 
 
 class PointsDensity(Actor):
+    """Actor showing the 3D density of a point cloud as a volume."""
+
     def __init__(
         self,
-        data,
-        name=None,
-        dims=(40, 40, 40),
-        radius=None,
-        colors="Dark2",
-        **kwargs,
-    ):
+        data: npt.NDArray,
+        name: str | None = None,
+        dims: tuple[int, int, int] = (40, 40, 40),
+        radius: float | None = None,
+        colors: str = "Dark2",
+        **kwargs: Any,
+    ) -> None:
         """
-        Creates a Volume actor showing the 3d density of a set
-        of points.
-
-        :param data: np.ndarray, Nx3 array with cell coordinates
-        :param colors: str, matplotlib colormap
-
-
-        from vedo:
-            Generate a density field from a point cloud. Input can also be a set of 3D coordinates.
-            Output is a ``Volume``.
-            The local neighborhood is specified as the `radius` around each sample position (each voxel).
-            The density is expressed as the number of counts in the radius search.
-
-            :param int,list dims: number of voxels in x, y and z of the output Volume.
-
+        Parameters
+        ----------
+        data
+            Nx3 array of point coordinates.
+        name
+            Actor name.
+        dims
+            Number of voxels in x, y, z of the output Volume. Default ``(40, 40, 40)``.
+        radius
+            Neighbourhood radius for density estimation. If None, vedo infers it.
+        colors
+            Matplotlib colormap name. Default ``"Dark2"``.
+        **kwargs
+            Additional keyword arguments forwarded to vedo's ``density``.
         """
         logger.debug("Creating a PointsDensity actor")
 

--- a/brainrender/actors/ruler.py
+++ b/brainrender/actors/ruler.py
@@ -1,4 +1,7 @@
+"""Ruler actors for measuring distances in brainrender scenes."""
+
 import numpy as np
+import numpy.typing as npt
 from loguru import logger
 from vedo import merge
 from vedo.shapes import Line, Sphere, Text3D
@@ -7,18 +10,35 @@ from vedo.utils import mag, precision
 from brainrender.actor import Actor
 
 
-def ruler(p1, p2, unit_scale=1, units=None, s=50):
+def ruler(
+    p1: npt.ArrayLike,
+    p2: npt.ArrayLike,
+    unit_scale: float = 1,
+    units: str | None = None,
+    s: float = 50,
+) -> Actor:
     """
-    Creates a ruler showing the distance between two points.
+    Create a ruler showing the distance between two points.
     The ruler is composed of a line between the points and
     a text indicating the distance.
 
-    :param p1: list, np.ndarray with coordinates of first point
-    :param p2: list, np.ndarray with coordinates of second point
-    :param unit_scale: float. To scale the units (e.g. show mm instead of µm)
-    :param units: str, name of unit (e.g. 'mm')
-    :param s: float size of text
+    Parameters
+    ----------
+    p1
+        Coordinates of the first point.
+    p2
+        Coordinates of the second point.
+    unit_scale
+        Scale factor for the displayed units (e.g. 0.001 to show mm instead of µm).
+    units
+        Unit label string (e.g. ``"mm"``).
+    s
+        Text size. Default 50.
 
+    Returns
+    -------
+    Actor
+        A ruler actor showing the distance between the two points.
     """
     logger.debug(f"Creating a ruler actor between {p1} and {p2}")
     actors = []
@@ -51,16 +71,35 @@ def ruler(p1, p2, unit_scale=1, units=None, s=50):
 
 
 def ruler_from_surface(
-    p1, root, unit_scale=1, axis=1, units=None, s=50
+    p1: npt.ArrayLike,
+    root: Actor,
+    unit_scale: float = 1,
+    axis: int = 1,
+    units: str | None = None,
+    s: float = 50,
 ) -> Actor:
     """
-    Creates a ruler between a point and the brain's surface
-    :param p1: list, np.ndarray with coordinates of  point
-    :param root: mesh or actor with brain's root
-    :param axis: int, index of axis along which distance is computed
-    :param unit_scale: float. To scale the units (e.g. show mm instead of µm)
-    :param units: str, name of unit (e.g. 'mm')
-    :param s: float size of text
+    Create a ruler between a point and the brain's surface.
+
+    Parameters
+    ----------
+    p1
+        Coordinates of the point.
+    root
+        Actor with the brain's root mesh.
+    unit_scale
+        Scale factor for the displayed units (e.g. 0.001 to show mm instead of µm).
+    axis
+        Index of the axis along which the distance is computed. Default 1.
+    units
+        Unit label string (e.g. ``"mm"``).
+    s
+        Text size. Default 50.
+
+    Returns
+    -------
+    Actor
+        A ruler actor showing the distance from the point to the brain surface.
     """
     logger.debug(f"Creating a ruler actor between {p1} and brain surface")
     # Get point on brain surface

--- a/brainrender/actors/streamlines.py
+++ b/brainrender/actors/streamlines.py
@@ -1,24 +1,43 @@
+"""Create actors for rendering axonal projection streamlines."""
+
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from loguru import logger
-from vedo import merge
+from vedo import Mesh, merge
 from vedo.shapes import Spheres, Tube
 
 from brainrender.actor import Actor
 
 
 def make_streamlines(
-    *streamlines, color="salmon", alpha=1, radius=10, show_injection=True
-):
+    *streamlines: pd.DataFrame,
+    color: str = "salmon",
+    alpha: float = 1,
+    radius: float = 10,
+    show_injection: bool = True,
+) -> list["Streamlines"]:
     """
-    Creates instances of Streamlines from data.
-    :param streamlines: pd.dataframes with streamlines data
-    :param radius: float. Radius of the Tube mesh used to render streamlines
-    :param color: str, name of the color to be used
-    :param alpha: float, transparency
-    :param show_injection: bool. If true spheres mark the injection sites
+    Create Streamlines actors from one or more dataframes.
+
+    Parameters
+    ----------
+    *streamlines
+        DataFrames with streamlines data.
+    color
+        Colour name. Default ``"salmon"``.
+    alpha
+        Transparency. Default 1.
+    radius
+        Radius of the Tube mesh. Default 10.
+    show_injection
+        If True, spheres mark the injection sites. Default True.
+
+    Returns
+    -------
+    list of Streamlines
+        A list of Streamlines actors, one for each input DataFrame.
     """
     return [
         Streamlines(
@@ -34,27 +53,41 @@ def make_streamlines(
 
 class Streamlines(Actor):
     """
-    Streamliens actor class.
-    Creates an actor from streamlines data (from a json file parsed with: get_streamlines_data)
+    Actor created from streamlines projection data.
+
+    Renders axonal streamlines as tube meshes, optionally marking
+    injection sites with spheres.
     """
 
     def __init__(
         self,
-        data,
-        radius=10,
-        color="salmon",
-        alpha=1,
-        show_injection=True,
-        name=None,
-    ):
+        data: pd.DataFrame | str | Path,
+        radius: float = 10,
+        color: str = "salmon",
+        alpha: float = 1,
+        show_injection: bool = True,
+        name: str | None = None,
+    ) -> None:
         """
-        Turns streamlines data to a mesh.
-        :param data: pd.DataFrame with streamlines points data
-        :param radius: float. Radius of the Tube mesh used to render streamlines
-        :param color: str, name of the color to be used
-        :param alpha: float, transparency
-        :param name: str, name of the actor.
-        :param show_injection: bool. If true spheres mark the injection sites
+        Parameters
+        ----------
+        data
+            DataFrame with streamlines points data, or a path to a JSON file.
+        radius
+            Radius of the Tube mesh. Default 10.
+        color
+            Colour name. Default ``"salmon"``.
+        alpha
+            Transparency. Default 1.
+        show_injection
+            If True, spheres mark the injection sites. Default True.
+        name
+            Actor name. Default ``"Streamlines"``.
+
+        Raises
+        ------
+        TypeError
+            If ``data`` is not a DataFrame or a path to a JSON file.
         """
         logger.debug("Creating a streamlines actor")
         if isinstance(data, (str, Path)):
@@ -73,7 +106,26 @@ class Streamlines(Actor):
         name = name or "Streamlines"
         Actor.__init__(self, mesh, name=name, br_class="Streamliness")
 
-    def _make_mesh(self, data, show_injection=True):
+    def _make_mesh(
+        self,
+        data: pd.DataFrame,
+        show_injection: bool = True,
+    ) -> Mesh:
+        """
+        Build a merged vedo mesh from streamlines and injection sites.
+
+        Parameters
+        ----------
+        data
+            DataFrame with ``lines`` and ``injection_sites`` columns.
+        show_injection
+            If True, add spheres at injection sites.
+
+        Returns
+        -------
+        vedo.Mesh
+            A merged vedo mesh containing the streamlines and, optionally, injection sites.
+        """
         lines = []
         if len(data["lines"]) == 1:
             try:

--- a/brainrender/actors/volume.py
+++ b/brainrender/actors/volume.py
@@ -16,6 +16,7 @@ class Volume(Actor):
     Render a 3D numpy array as a surface mesh or vedo Volume.
     By default the volume is represented as an isosurface.
     """
+
     def __init__(
         self,
         griddata: npt.NDArray | VedoVolume | str | Path,

--- a/brainrender/actors/volume.py
+++ b/brainrender/actors/volume.py
@@ -1,6 +1,10 @@
+"""Volume actor for rendering 3D numpy arrays as surfaces or volumes."""
+
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from loguru import logger
 from vedo import Volume as VedoVolume
 
@@ -8,38 +12,45 @@ from brainrender.actor import Actor
 
 
 class Volume(Actor):
+    """
+    Render a 3D numpy array as a surface mesh or vedo Volume.
+    By default the volume is represented as an isosurface.
+    """
     def __init__(
         self,
-        griddata,
-        voxel_size=1,
-        cmap="bwr",
-        min_quantile=None,
-        min_value=None,
-        name=None,
-        br_class=None,
-        as_surface=True,
-        **volume_kwargs,
-    ):
+        griddata: npt.NDArray | VedoVolume | str | Path,
+        voxel_size: int = 1,
+        cmap: str = "bwr",
+        min_quantile: float | None = None,
+        min_value: float | None = None,
+        name: str | None = None,
+        br_class: str | None = None,
+        as_surface: bool = True,
+        **volume_kwargs: Any,
+    ) -> None:
         """
-        Takes a 3d numpy array with volumetric data
-        and returns an Actor with mesh: vedo.Volume.isosurface or a vedo.Volume.
-        BY default the volume is represented as a surface
-
-        To extract the surface:
-            The isosurface needs a lower bound threshold, this can be
-            either a user defined hard value (min_value) or the value
-            corresponding to some percentile of the grid data.
-
-        :param griddata: np.ndarray, 3d array with grid data. Can also be a vedo Volume
-            or a file path pointing to a .npy file
-        :param griddata: np.ndarray, 3d array with grid data
-        :param voxel_size: int, size of each voxel in microns
-        :param min_quantile: float, percentile for threshold
-        :param min_value: float, value for threshold
-        :param cmap: str, name of colormap to use
-        :param as_surface, bool. default True. If True
-            a surface mesh is returned instead of the whole volume
-        :param volume_kwargs: keyword arguments for vedo's Volume class
+        Parameters
+        ----------
+        griddata
+            3D array with grid data. Can also be a vedo Volume or a path
+            to a ``.npy`` file.
+        voxel_size
+            Size of each voxel in microns. Default 1.
+        cmap
+            Colormap name. Default ``"bwr"``.
+        min_quantile
+            Percentile threshold for isosurface extraction.
+        min_value
+            Hard value threshold for isosurface extraction.
+        name
+            Actor name. Default ``"Volume"``.
+        br_class
+            Brainrender class type. Default ``"Volume"``.
+        as_surface
+            If True, return an isosurface mesh instead of the full volume.
+            Default True.
+        **volume_kwargs
+            Keyword arguments forwarded to vedo's Volume class.
         """
         logger.debug("Creating a Volume actor")
         # Create mesh
@@ -73,9 +84,31 @@ class Volume(Actor):
             self, mesh, name=name or "Volume", br_class=br_class or "Volume"
         )
 
-    def _from_numpy(self, griddata, voxel_size, color, **volume_kwargs):
+    def _from_numpy(
+        self,
+        griddata: npt.NDArray,
+        voxel_size: int,
+        color: str,
+        **volume_kwargs: Any,
+    ) -> VedoVolume:
         """
-        Creates a vedo.Volume actor from a 3D numpy array with volume data.
+        Create a vedo Volume from a 3D numpy array.
+
+        Parameters
+        ----------
+        griddata
+            3D array with volume data.
+        voxel_size
+            Size of each voxel in microns.
+        color
+            Colormap name to apply.
+        **volume_kwargs
+            Keyword arguments forwarded to vedo's Volume class.
+
+        Returns
+        -------
+        VedoVolume
+            A vedo volume created from the input 3D array.
         """
         vvol = VedoVolume(
             griddata,
@@ -92,9 +125,37 @@ class Volume(Actor):
         # vvol.apply_transform(mtx)
         return vvol
 
-    def _from_file(self, filepath, voxel_size, color, **volume_kwargs):
+    def _from_file(
+        self,
+        filepath: str | Path,
+        voxel_size: int,
+        color: str,
+        **volume_kwargs: Any,
+    ) -> VedoVolume:
         """
-        Loads a .npy file and returns a vedo Volume actor.
+        Load a ``.npy`` file and return a vedo Volume.
+
+        Parameters
+        ----------
+        filepath
+            Path to the ``.npy`` file.
+        voxel_size
+            Size of each voxel in microns.
+        color
+            Colormap name to apply.
+        **volume_kwargs
+            Keyword arguments forwarded to vedo's Volume class.
+
+        Returns
+        -------
+        VedoVolume
+
+        Raises
+        ------
+        FileExistsError
+            If the file does not exist.
+        ValueError
+            If the file is not a ``.npy`` file.
         """
         filepath = Path(filepath)
         if not filepath.exists():


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
 - The codebase lacked consistent docstrings, making Sphinx autodoc output incomplete and hard to read.

**What does this PR do?**
 - Adds/updates NumPy-style docstrings (module, class, method, function level) in actors modules.

## References
 - Part of **Issue**-[96](https://github.com/brainglobe/BrainGlobe/issues/96)

## How has this PR been tested?
 - No functional changes, existing tests pass.

## Is this a breaking change?
 - No.

## Does this PR require an update to the documentation?
 - Yes.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
