### PR TITLE
Pin cloud-volume version to 12 to aid environment resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
-    "cloud-volume>=3.11.0",
+    "cloud-volume>=12",
     "brainglobe-space>=1.0.0",
     "brainglobe-utils>=0.5.0",
     "h5py",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Installing the `brainglobe-meta` could pull in the wrong version of `cloud-volume` by backtracking to a version from 2021. This pins the version to a modern one (12).