### PR TITLE
ci: migrate from tox to uv test action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -71,11 +71,12 @@ jobs:
 
       # Run tests
       - name: Run tests
-        uses: neuroinformatics-unit/actions/test-uv@main
+        uses: neuroinformatics-unit/actions/test-uv@add-mesa3d-offscreen
         with:
           python-version: "${{ matrix.python-version }}"
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
           use-headless: 'true'
+          install-mesa3d-offscreen: ${{ matrix.os != 'windows-latest' }}
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,9 +61,6 @@ jobs:
         run: brew install hdf5
 
       # Helps set up VTK with a headless display
-      - uses: pyvista/setup-headless-display-action@v3
-
-      # Sets up ffmpeg to we can run video tests on CI
       - uses: FedericoCarboni/setup-ffmpeg@v2
         if: matrix.os != 'macos-latest'
         id: setup-ffmpeg
@@ -73,11 +70,12 @@ jobs:
         run: brew install ffmpeg
 
       # Run tests
-      - uses: neuroinformatics-unit/actions/test@v2
+      - name: Run tests
+        uses: neuroinformatics-unit/actions/test-uv@main
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
-
+          use-headless: 'true'
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,13 +23,12 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/lint@v2
-
+      - uses: neuroinformatics-unit/actions/lint@9b53ffe93baaafe5533e1f295a3c069bbc17ba36 # v3.0.1
   manifest:
     name: Check Manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/check_manifest@v2
+      - uses: neuroinformatics-unit/actions/check_manifest@9b53ffe93baaafe5533e1f295a3c069bbc17ba36 # v3.0.1
 
   test:
     needs: [linting, manifest]
@@ -49,7 +48,7 @@ jobs:
 
     steps:
       - name: Cache brainglobe directory
-        uses: actions/cache@v3
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: | # ensure we don't cache any interrupted atlas download and extraction, if e.g. we cancel the workflow manually
             ~/.brainglobe
@@ -71,7 +70,7 @@ jobs:
 
       # Run tests
       - name: Run tests
-        uses: neuroinformatics-unit/actions/test-uv@add-mesa3d-offscreen
+        uses: neuroinformatics-unit/actions/test-uv@9b53ffe93baaafe5533e1f295a3c069bbc17ba36 #v3.0.1
         with:
           python-version: "${{ matrix.python-version }}"
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -80,7 +79,7 @@ jobs:
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
         with:
           status: ${{ job.status }} # required
           notify_when: 'failure'
@@ -94,7 +93,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v2
+    - uses: neuroinformatics-unit/actions/build_sdist_wheels@9b53ffe93baaafe5533e1f295a3c069bbc17ba36 # v3.0.1
 
 
   upload_all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
     "pytest",
     "pytest-cov",
     "coverage",
-    "tox",
     "black",
     "mypy",
     "pre-commit",
@@ -65,7 +64,6 @@ dev = [
     "setuptools_scm",
 ]
 nb = ["jupyter", "k3d"]
-
 
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
@@ -78,9 +76,8 @@ include-package-data = true
 include = ["brainrender*"]
 exclude = ["tests*", "docs*", "examples*", "imgs*"]
 
-
 [tool.pytest.ini_options]
-addopts = "--cov=brainrender"
+addopts = "--cov=brainrender --cov-report=xml --color=yes -vv"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "local: marks test as local (not for CI)",
@@ -113,29 +110,3 @@ ignore = ["E501", "E402"]
 
 [tool.ruff.lint]
 select = ["I", "E", "F"]
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py{311,312,313}
-isolated_build = True
-
-[gh-actions]
-python =
-    3.11: py311
-    3.12: py312
-    3.13: py313
-
-[testenv]
-extras =
-    dev
-commands =
-    pytest -v --color=yes --cov=brainrender --cov-report=xml
-passenv =
-    CI
-    GITHUB_ACTIONS
-    DISPLAY
-    XAUTHORITY
-    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
-    PYVISTA_OFF_SCREEN
-"""


### PR DESCRIPTION
Migrate CI from `neuroinformatics-unit/actions/test@v2` (tox) to `neuroinformatics-unit/actions/test-uv@main` (pure uv).